### PR TITLE
feat: Implement custom docker image

### DIFF
--- a/operate/resource.py
+++ b/operate/resource.py
@@ -94,7 +94,9 @@ class LocalResource:
         for pname, ptype in cls.__annotations__.items():
             if pname.startswith("_"):
                 continue
-            kwargs[pname] = deserialize(obj=obj[pname], otype=ptype)
+
+            if pname in obj:
+                kwargs[pname] = deserialize(obj=obj[pname], otype=ptype)
         return cls(**kwargs)
 
     @classmethod


### PR DESCRIPTION
## Proposed changes

This PR implements a change that will allow the service template to contain a custom docker image field, and pass that to open-autonomy in order to create the docker compose file with this custom image. It also sets up the environment variables of the docker container based on the service configurations.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
