### PR TITLE
Relative package path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -472,7 +472,7 @@ Returns the list of existing service configurations.
     "keys": [...],
     "name": "valory/trader_omen_gnosis",
     "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-    "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis",
+    "package_path": "trader_pearl",
     "version": 4
   },
   ...
@@ -519,7 +519,7 @@ Create a service configuration using a template.
   "keys": [...],
   "name": "valory/trader_omen_gnosis",
   "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-  "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis",
+  "package_path": "trader_pearl",
   "version": 4
 }
 ```
@@ -567,7 +567,7 @@ The response contains an array of the services which have been updated (an empty
     "keys": [...],
     "name": "valory/trader_omen_gnosis",
     "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-    "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis",
+    "package_path": "trader_pearl",
     "version": 4
   },
   ...
@@ -628,7 +628,7 @@ Returns the service configuration `service_config_id`.
     "keys": [...],
     "name": "valory/trader_omen_gnosis",
     "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-    "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis",
+    "package_path": "trader_pearl",
     "version": 4
   }
 
@@ -675,7 +675,7 @@ The response contains the updated service configuration following the on-chain o
   "keys": [...],
   "name": "valory/trader_omen_gnosis",
   "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-  "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis"
+  "package_path": "trader_pearl"
 }
 
 ```
@@ -722,7 +722,7 @@ Update service configuration `service_config_id` with the provided template.
     "keys": [...],
     "name": "valory/trader_omen_gnosis",
     "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-    "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis"
+    "package_path": "trader_pearl"
   }
 
   ```
@@ -780,7 +780,7 @@ Partial update service configuration `service_config_id` with the provided (part
     "keys": [...],
     "name": "valory/trader_omen_gnosis",
     "service_config_id": "sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39",
-    "service_path": "/home/user/.operate/services/sc-85a7a12a-8c6b-46b8-919a-b8a3b8e3ad39/trader_omen_gnosis"
+    "package_path": "trader_pearl"
   }
 
   ```

--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -432,7 +432,7 @@ class ServiceManager:
             chain_data.token = t.cast(
                 int,
                 ocm.mint(
-                    package_path=service.service_path,
+                    package_path=service.package_absolute_path_absolute_path,
                     agent_id=staking_params["agent_ids"][0],
                     number_of_slots=service.helper.config.number_of_agents,
                     cost_of_bond=(
@@ -778,7 +778,7 @@ class ServiceManager:
                     sftxb.new_tx()
                     .add(
                         sftxb.get_mint_tx_data(
-                            package_path=service.service_path,
+                            package_path=service.package_absolute_path,
                             agent_id=agent_id,
                             number_of_slots=service.helper.config.number_of_agents,
                             cost_of_bond=(
@@ -830,7 +830,7 @@ class ServiceManager:
                 sftxb.new_tx()
                 .add(
                     sftxb.get_mint_tx_data(
-                        package_path=service.service_path,
+                        package_path=service.package_absolute_path,
                         agent_id=agent_id,
                         number_of_slots=service.helper.config.number_of_agents,
                         cost_of_bond=(

--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -993,7 +993,7 @@ class Service(LocalResource):
                 package_temp_path = Path(
                     IPFSTool().download(
                         hash_id=self.hash,
-                        target_dir=temp_dir + "/",
+                        target_dir=temp_dir,
                     )
                 )
                 target_path = self.path / package_temp_path.name

--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -97,7 +97,7 @@ SAFE_CONTRACT_ADDRESS = "safe_contract_address"
 ALL_PARTICIPANTS = "all_participants"
 CONSENSUS_THRESHOLD = "consensus_threshold"
 DELETE_PREFIX = "delete_"
-SERVICE_CONFIG_VERSION = 5
+SERVICE_CONFIG_VERSION = 6
 SERVICE_CONFIG_PREFIX = "sc-"
 
 NON_EXISTENT_MULTISIG = "0xm"
@@ -435,7 +435,7 @@ class Deployment(LocalResource):
 
         service = Service.load(path=self.path)
         builder = ServiceBuilder.from_dir(
-            path=service.service_path,
+            path=service.package_absolute_path,
             keys_file=self.path / KEYS_JSON,
             number_of_agents=len(service.keys),
         )
@@ -493,7 +493,7 @@ class Deployment(LocalResource):
         )
         try:
             builder = ServiceBuilder.from_dir(
-                path=service.service_path,
+                path=service.package_absolute_path,
                 keys_file=keys_file,
                 number_of_agents=len(service.keys),
             )
@@ -617,7 +617,7 @@ class Deployment(LocalResource):
         )
         try:
             builder = ServiceBuilder.from_dir(
-                path=service.service_path,
+                path=service.package_absolute_path,
                 keys_file=keys_file,
                 number_of_agents=len(service.keys),
             )
@@ -743,7 +743,7 @@ class Service(LocalResource):
     env_variables: EnvVariables
 
     path: Path
-    service_path: Path
+    package_path: Path
 
     name: t.Optional[str] = None
 
@@ -931,18 +931,22 @@ class Service(LocalResource):
         data["version"] = SERVICE_CONFIG_VERSION
 
         # Redownload service path
-        service_path = path / Path(data["service_path"]).name
-        if service_path.exists() and service_path.is_dir():
-            print("EXISTS")
-            shutil.rmtree(service_path)
+        if "service_path" in data:
+            package_absolute_path = path / Path(data["service_path"]).name
+            data.pop("service_path")
+        else:
+            package_absolute_path = path / data["package_path"]
 
-        service_path = Path(
+        if package_absolute_path.exists() and package_absolute_path.is_dir():
+            shutil.rmtree(package_absolute_path)
+
+        package_absolute_path = Path(
             IPFSTool().download(
                 hash_id=data["hash"],
                 target_dir=path,
             )
         )
-        data["service_path"] = str(service_path)
+        data["package_path"] = str(package_absolute_path.name)
 
         with open(path / Service._file, "w", encoding="utf-8") as file:
             json.dump(data, file, indent=2)
@@ -958,7 +962,7 @@ class Service(LocalResource):
     def helper(self) -> ServiceHelper:
         """Get service helper."""
         if self._helper is None:
-            self._helper = ServiceHelper(path=self.service_path)
+            self._helper = ServiceHelper(path=self.package_absolute_path)
         return t.cast(ServiceHelper, self._helper)
 
     @property
@@ -972,6 +976,35 @@ class Service(LocalResource):
             self._deployment = Deployment.new(path=self.path)
         return t.cast(Deployment, self._deployment)
 
+    @property
+    def package_absolute_path(self) -> Path:
+        """Get the package_absolute_path."""
+        self._ensure_package_exists()
+        package_absolute_path = self.path / self.package_path
+        return package_absolute_path
+
+    def _ensure_package_exists(self) -> None:
+        package_absolute_path = self.path / self.package_path
+        if (
+            not package_absolute_path.exists()
+            or not (package_absolute_path / "service.yaml").exists()
+        ):
+            with tempfile.TemporaryDirectory(dir=self.path) as temp_dir:
+                package_temp_path = Path(
+                    IPFSTool().download(
+                        hash_id=self.hash,
+                        target_dir=temp_dir + "/",
+                    )
+                )
+                target_path = self.path / package_temp_path.name
+
+                if target_path.exists():
+                    shutil.rmtree(target_path)
+
+                shutil.move(package_temp_path, target_path)
+                self.package_path = target_path.name
+                self.store()
+
     @staticmethod
     def new(  # pylint: disable=too-many-locals
         keys: Keys,
@@ -983,14 +1016,14 @@ class Service(LocalResource):
         service_config_id = Service.get_new_service_config_id(storage)
         path = storage / service_config_id
         path.mkdir()
-        service_path = Path(
+        package_absolute_path = Path(
             IPFSTool().download(
                 hash_id=service_template["hash"],
                 target_dir=path,
             )
         )
 
-        ledger_configs = ServiceHelper(path=service_path).ledger_configs()
+        ledger_configs = ServiceHelper(path=package_absolute_path).ledger_configs()
 
         chain_configs = {}
         for chain, config in service_template["configurations"].items():
@@ -1022,8 +1055,8 @@ class Service(LocalResource):
             home_chain=service_template["home_chain"],
             hash_history={current_timestamp: service_template["hash"]},
             chain_configs=chain_configs,
-            path=service_path.parent,
-            service_path=service_path,
+            path=package_absolute_path.parent,
+            package_path=package_absolute_path.name,
             env_variables=service_template["env_variables"],
         )
         service.store()
@@ -1031,7 +1064,9 @@ class Service(LocalResource):
 
     def service_public_id(self, include_version: bool = True) -> str:
         """Get the public id (based on the service hash)."""
-        with (self.service_path / "service.yaml").open("r", encoding="utf-8") as fp:
+        with (self.package_absolute_path / "service.yaml").open(
+            "r", encoding="utf-8"
+        ) as fp:
             service_yaml, *_ = yaml_load_all(fp)
 
         public_id = f"{service_yaml['author']}/{service_yaml['name']}"
@@ -1135,14 +1170,17 @@ class Service(LocalResource):
         self.description = service_template.get("description", self.description)
         self.name = service_template.get("name", self.name)
 
-        shutil.rmtree(self.service_path)
-        service_path = Path(
+        package_absolute_path = self.path / self.package_path
+        if package_absolute_path.exists():
+            shutil.rmtree(package_absolute_path)
+
+        package_absolute_path = Path(
             IPFSTool().download(
                 hash_id=self.hash,
                 target_dir=self.path,
             )
         )
-        self.service_path = service_path
+        self.package_path = package_absolute_path.name
 
         # env_variables
         if partial_update:
@@ -1154,7 +1192,7 @@ class Service(LocalResource):
         # chain_configs
         # TODO support remove chains for non-partial updates
         # TODO ensure all and only existing chains are passed for non-partial updates
-        ledger_configs = ServiceHelper(path=self.service_path).ledger_configs()
+        ledger_configs = ServiceHelper(path=self.package_absolute_path).ledger_configs()
         for chain, new_config in service_template.get("configurations", {}).items():
             if chain in self.chain_configs:
                 # The template is providing a chain configuration that already

--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -1002,7 +1002,7 @@ class Service(LocalResource):
                     shutil.rmtree(target_path)
 
                 shutil.move(package_temp_path, target_path)
-                self.package_path = target_path.name
+                self.package_path = Path(target_path.name)
                 self.store()
 
     @staticmethod
@@ -1056,7 +1056,7 @@ class Service(LocalResource):
             hash_history={current_timestamp: service_template["hash"]},
             chain_configs=chain_configs,
             path=package_absolute_path.parent,
-            package_path=package_absolute_path.name,
+            package_path=Path(package_absolute_path.name),
             env_variables=service_template["env_variables"],
         )
         service.store()
@@ -1180,7 +1180,7 @@ class Service(LocalResource):
                 target_dir=self.path,
             )
         )
-        self.package_path = package_absolute_path.name
+        self.package_path = Path(package_absolute_path.name)
 
         # env_variables
         if partial_update:

--- a/tests/test_services_service.py
+++ b/tests/test_services_service.py
@@ -57,6 +57,7 @@ DEFAULT_CONFIG_KWARGS = {
     "instance_0": "0x0000000000000000000000000000000000000001",
     "multisig": "0x0000000000000000000000000000000000000020",
     "service_config_id": "sc-00000000-0000-0000-0000-000000000000",
+    "package_path": "trader_pearl",
 }
 
 
@@ -232,7 +233,7 @@ def get_config_json_data_v4(**kwargs: t.Any) -> t.Dict[str, t.Any]:
 
 
 def get_config_json_data_v5(**kwargs: t.Any) -> t.Dict[str, t.Any]:
-    """get_config_json_data_v4"""
+    """get_config_json_data_v5"""
 
     return {
         "version": 5,
@@ -276,12 +277,62 @@ def get_config_json_data_v5(**kwargs: t.Any) -> t.Dict[str, t.Any]:
         },
         "description": kwargs.get("description"),
         "env_variables": {},
-        "service_path": kwargs.get("service_path"),
+        "service_path": f"/home/user/.operate/services/{kwargs.get('service_config_id')}/trader_pearl",
         "name": kwargs.get("name"),
     }
 
 
-get_expected_data = get_config_json_data_v5
+def get_config_json_data_v6(**kwargs: t.Any) -> t.Dict[str, t.Any]:
+    """get_config_json_data_v6"""
+
+    return {
+        "version": 6,
+        "service_config_id": kwargs.get("service_config_id"),
+        "hash": kwargs.get("hash"),
+        "hash_history": {kwargs.get("hash_timestamp"): kwargs.get("hash")},
+        "keys": [
+            {
+                "ledger": "ethereum",
+                "address": kwargs.get("keys_address_0"),
+                "private_key": kwargs.get("keys_private_key_0"),
+            }
+        ],
+        "home_chain": "gnosis",
+        "chain_configs": {
+            "gnosis": {
+                "ledger_config": {"rpc": kwargs.get("rpc"), "chain": "gnosis"},
+                "chain_data": {
+                    "instances": [kwargs.get("instance_0")],
+                    "token": kwargs.get("token"),
+                    "multisig": kwargs.get("multisig"),
+                    "staked": kwargs.get("staked"),
+                    "on_chain_state": kwargs.get("on_chain_state"),
+                    "user_params": {
+                        "staking_program_id": kwargs.get("staking_program_id"),
+                        "nft": kwargs.get("nft"),
+                        "threshold": kwargs.get("threshold"),
+                        "agent_id": kwargs.get("agent_id"),
+                        "use_staking": kwargs.get("use_staking"),
+                        "use_mech_marketplace": kwargs.get("use_mech_marketplace"),
+                        "cost_of_bond": kwargs.get("cost_of_bond"),
+                        "fund_requirements": {
+                            "0x0000000000000000000000000000000000000000": {
+                                "agent": kwargs.get("fund_requirements_agent"),
+                                "safe": kwargs.get("fund_requirements_safe"),
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "description": kwargs.get("description"),
+        "env_variables": {},
+        "package_path": kwargs.get("package_path"),
+        "name": kwargs.get("name"),
+    }
+
+
+get_expected_data = get_config_json_data_v6
 
 
 class TestService:
@@ -299,6 +350,7 @@ class TestService:
             get_config_json_data_v2,
             get_config_json_data_v3,
             get_config_json_data_v4,
+            get_config_json_data_v5,
         ],
     )
     def test_service_migrate_format(


### PR DESCRIPTION
## Proposed changes

This PR solves a few common issues that cause frequent blocking issues to the users: 

* (Breaking change) Change field name `service_path` to `package_path` on `config.json`.
* `package_path` is now relative to the service configuration folder. This allows for seamless transfer configuration from one machine to another without having to manually edit `config.json`.
* Delete and auto-download service package if missing or corrupted.
* Addressed migration and tests.

Note: `computed` environment variables need not be addressed, as they are recomputed each time the deployment is launched.

:warning:  **Breaking change**
Once the `.operate` folder is opened with this version of the middleware it will no longer be compatible with a previous version.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
