### PR TITLE
Fix: Check claimable rewards before QS claim

### DIFF
--- a/operate/quickstart/analyse_logs.py
+++ b/operate/quickstart/analyse_logs.py
@@ -107,6 +107,9 @@ def analyse_logs(
         print(f"Config file '{config_file}' not found.")
         sys.exit(1)
 
+    operate.service_manager().migrate_service_configs()
+    operate.wallet_manager.migrate_wallet_configs()
+
     # Auto-detect the logs directory
     build_dir = find_build_directory(config_file, operate)
     logs_dir = build_dir / "persistent_data" / "logs"

--- a/operate/quickstart/reset_password.py
+++ b/operate/quickstart/reset_password.py
@@ -35,6 +35,9 @@ def reset_password(operate: "OperateApp") -> None:
     """Reset password."""
     print_title("Reset your password")
 
+    operate.service_manager().migrate_service_configs()
+    operate.wallet_manager.migrate_wallet_configs()
+
     # check if agent was started before
     if not (operate._path / "user.json").exists():
         print("No previous agent setup found. Exiting.")

--- a/operate/quickstart/reset_staking.py
+++ b/operate/quickstart/reset_staking.py
@@ -44,6 +44,9 @@ def reset_staking(operate: "OperateApp", config_path: str) -> None:
     with open(config_path, "r") as config_file:
         template = json.load(config_file)
 
+    operate.service_manager().migrate_service_configs()
+    operate.wallet_manager.migrate_wallet_configs()
+
     print_title("Reset your staking program preference")
 
     # check if agent was started before

--- a/operate/quickstart/stop_service.py
+++ b/operate/quickstart/stop_service.py
@@ -44,6 +44,9 @@ def stop_service(operate: "OperateApp", config_path: str) -> None:
 
     print_title(f"Stop {template['name']} Quickstart")
 
+    operate.service_manager().migrate_service_configs()
+    operate.wallet_manager.migrate_wallet_configs()
+
     # check if agent was started before
     config = load_local_config(
         operate=operate, service_name=cast(str, template["name"])

--- a/operate/quickstart/terminate_on_chain_service.py
+++ b/operate/quickstart/terminate_on_chain_service.py
@@ -43,6 +43,9 @@ def terminate_service(operate: "OperateApp", config_path: str) -> None:
 
     print_title(f"Terminate {template['name']} on-chain service")
 
+    operate.service_manager().migrate_service_configs()
+    operate.wallet_manager.migrate_wallet_configs()
+
     # check if agent was started before
     config = load_local_config(
         operate=operate, service_name=cast(str, template["name"])

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -228,6 +228,15 @@ class StakingManager(OnChainHelper):
         available_rewards = instance.functions.availableRewards().call()
         return available_rewards
 
+    def claimable_rewards(self, staking_contract: str, service_id: int) -> int:
+        """Get the claimable staking rewards on the staking contract"""
+        instance = self.staking_ctr.get_instance(
+            ledger_api=self.ledger_api,
+            contract_address=staking_contract,
+        )
+        claimable_rewards = instance.functions.calculateStakingReward(service_id).call()
+        return claimable_rewards
+
     def service_info(self, staking_contract: str, service_id: int) -> dict:
         """Get the service onchain info"""
         return self.staking_ctr.get_service_info(
@@ -810,6 +819,19 @@ class _ChainUtil:
             staking_contract=staking_contract,
         )
         return available_rewards > 0
+
+    def staking_rewards_claimable(self, staking_contract: str, service_id: int) -> bool:
+        """Check if there are claimable staking rewards on the staking contract"""
+        self._patch()
+        claimable_rewards = StakingManager(
+            key=self.wallet.key_path,
+            password=self.wallet.password,
+            chain_type=self.chain_type,
+        ).claimable_rewards(
+            staking_contract=staking_contract,
+            service_id=service_id,
+        )
+        return claimable_rewards > 0
 
     def staking_status(self, service_id: int, staking_contract: str) -> StakingState:
         """Stake the service"""


### PR DESCRIPTION
## Proposed changes

- [x] Check if any claimable rewards are available before doing the `claim` transaction in quickstart
- [x] Migrate service config in other QS scripts also

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
