### PR TITLE
Add creation hash and initial transfer hashes on safe creation

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -575,7 +575,7 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
     @app.get("/api/wallet/safe/{chain}")
     @with_retries
     async def _get_safe(request: Request) -> t.List[t.Dict]:
-        """Create wallet safe"""
+        """Get safe address"""
         chain = Chain.from_string(request.path_params["chain"])
         ledger_type = chain.ledger_type
         manager = operate.wallet_manager
@@ -633,27 +633,36 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
         if backup_owner:
             backup_owner = ledger_api.api.to_checksum_address(backup_owner)
 
-        wallet.create_safe(  # pylint: disable=no-member
+        tx_hash = wallet.create_safe(  # pylint: disable=no-member
             chain=chain,
             backup_owner=backup_owner,
         )
+        create_tx_link = tx_hash
 
         safe_address = t.cast(str, safes.get(chain))
         initial_funds = data.get("initial_funds", DEFAULT_NEW_SAFE_FUNDS_AMOUNT[chain])
 
+        transfer_tx_links = {}
         for asset, amount in initial_funds.items():
-            wallet.transfer_asset(
+            tx_hash = wallet.transfer_asset(
                 to=safe_address,
                 amount=amount,
                 chain=chain,
                 asset=asset,
                 from_safe=False,
             )
+            transfer_tx_links[asset] = tx_hash
 
         return JSONResponse(
-            content={"safe": safes.get(chain), "message": "Safe created!"}
+            content={
+                "create_tx": create_tx_link,
+                "transfer_txs": transfer_tx_links,
+                "safe": safes.get(chain),
+                "message": "Safe created!"
+            }
         )
 
+    # TODO possibly unused endpoint
     @app.post("/api/wallet/safes")
     @with_retries
     async def _create_safes(request: Request) -> t.List[t.Dict]:
@@ -730,7 +739,7 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
 
         if "chain" not in data:
             return JSONResponse(
-                content={"error": "You need to specify a chain to updae a safe."},
+                content={"error": "You need to specify a chain to update a safe."},
                 status_code=401,
             )
 

--- a/operate/wallet/master.py
+++ b/operate/wallet/master.py
@@ -129,7 +129,7 @@ class MasterWallet(LocalResource):
         chain: Chain,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds to the given account."""
         raise NotImplementedError()
 
@@ -142,7 +142,7 @@ class MasterWallet(LocalResource):
         chain: Chain,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds to the given account."""
         raise NotImplementedError()
 
@@ -154,7 +154,7 @@ class MasterWallet(LocalResource):
         asset: str = ZERO_ADDRESS,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer erc20/native assets to the given account."""
         raise NotImplementedError()
 
@@ -178,7 +178,7 @@ class MasterWallet(LocalResource):
         chain: Chain,
         backup_owner: t.Optional[str] = None,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Create safe."""
         raise NotImplementedError()
 
@@ -241,7 +241,7 @@ class EthereumMasterWallet(MasterWallet):
 
     def _transfer_from_eoa(
         self, to: str, amount: int, chain: Chain, rpc: t.Optional[str] = None
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds from EOA wallet."""
         ledger_api = t.cast(EthereumApi, self.ledger_api(chain=chain, rpc=rpc))
         tx_helper = TxSettler(
@@ -278,22 +278,22 @@ class EthereumMasterWallet(MasterWallet):
             )
 
         setattr(tx_helper, "build", _build_tx)  # noqa: B010
-        tx_helper.transact(lambda x: x, "", kwargs={})
+        tx_receipt = tx_helper.transact(lambda x: x, "", kwargs={})
+        tx_hash = tx_receipt.get("transactionHash", "").hex()
+        return tx_hash
+
 
     def _transfer_from_safe(
         self, to: str, amount: int, chain: Chain, rpc: t.Optional[str] = None
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds from safe wallet."""
-        if self.safes is not None:
-            transfer_from_safe(
-                ledger_api=self.ledger_api(chain=chain, rpc=rpc),
-                crypto=self.crypto,
-                safe=t.cast(str, self.safes[chain]),
-                to=to,
-                amount=amount,
-            )
-        else:
-            raise ValueError("Safes not initialized")
+        return transfer_from_safe(
+            ledger_api=self.ledger_api(chain=chain, rpc=rpc),
+            crypto=self.crypto,
+            safe=t.cast(str, self.safes[chain]),
+            to=to,
+            amount=amount,
+        )
 
     def _transfer_erc20_from_safe(
         self,
@@ -302,9 +302,9 @@ class EthereumMasterWallet(MasterWallet):
         amount: int,
         chain: Chain,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer erc20 from safe wallet."""
-        transfer_erc20_from_safe(
+        return transfer_erc20_from_safe(
             ledger_api=self.ledger_api(chain=chain, rpc=rpc),
             crypto=self.crypto,
             token=token,
@@ -320,7 +320,7 @@ class EthereumMasterWallet(MasterWallet):
         amount: int,
         chain: Chain,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer erc20 from EOA wallet."""
         wallet_address = self.address
         ledger_api = t.cast(EthereumApi, self.ledger_api(chain=chain, rpc=rpc))
@@ -355,7 +355,9 @@ class EthereumMasterWallet(MasterWallet):
             )
 
         setattr(tx_settler, "build", _build_transfer_tx)  # noqa: B010
-        tx_settler.transact(lambda x: x, "", kwargs={})
+        tx_receipt = tx_settler.transact(lambda x: x, "", kwargs={})
+        tx_hash = tx_receipt.get("transactionHash", "").hex()
+        return tx_hash
 
     def transfer(
         self,
@@ -364,7 +366,7 @@ class EthereumMasterWallet(MasterWallet):
         chain: Chain,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds to the given account."""
         if amount <= 0:
             return None
@@ -409,7 +411,7 @@ class EthereumMasterWallet(MasterWallet):
         chain: Chain,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Transfer funds to the given account."""
         if amount <= 0:
             return None
@@ -465,7 +467,7 @@ class EthereumMasterWallet(MasterWallet):
         asset: str = ZERO_ADDRESS,
         from_safe: bool = True,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """
         Transfer assets to the given account.
 
@@ -615,11 +617,11 @@ class EthereumMasterWallet(MasterWallet):
         chain: Chain,
         backup_owner: t.Optional[str] = None,
         rpc: t.Optional[str] = None,
-    ) -> None:
+    ) -> t.Optional[str]:
         """Create safe."""
         if chain in self.safe_chains:
-            return
-        safe, self.safe_nonce = create_gnosis_safe(
+            return None
+        safe, self.safe_nonce, tx_hash = create_gnosis_safe(
             ledger_api=self.ledger_api(chain=chain, rpc=rpc),
             crypto=self.crypto,
             backup_owner=backup_owner,
@@ -630,6 +632,7 @@ class EthereumMasterWallet(MasterWallet):
             self.safes = {}
         self.safes[chain] = safe
         self.store()
+        return tx_hash
 
     def update_backup_owner(
         self,


### PR DESCRIPTION
## Proposed changes

Add creation hash and initial transfer hashes on safe creation. Output of `POST /api/wallet/safe` is now:

```
{
  "create_tx": "0xac14dcd5938c71cd97388307c41477dc2f2a4e97b6b2641cef123a769898bd03",
  "transfer_txs": {
    "0x0000000000000000000000000000000000000000": "0x0036489a4a27b4ee1b7e4a37ae5597b895bf43e4cda25c7e6c0f1d02f8c098aa",
    "0xcE11e14225575945b8E6Dc0D4F2dD4C570f79d9f": "0x45304084049916535419d4b175074cdfcaeea59e3a5d34010854b3ac049261b2"
  },
  "safe": "0x361c01923013A434EAd279e57939B22ac97Ef901",
  "message": "Safe created!"
}
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
