### PR TITLE
Fix: Use TxSettler to handle various RPC responses

### DIFF
--- a/operate/data/contracts/uniswap_v2_erc20/contract.py
+++ b/operate/data/contracts/uniswap_v2_erc20/contract.py
@@ -198,7 +198,6 @@ class UniswapV2ERC20Contract(Contract):
         transfer_logs: List = []
 
         if transfer_logs_data:
-
             transfer_logs = cast(
                 List,
                 transfer_logs_data["logs"],


### PR DESCRIPTION
## Proposed changes

Comeback of `TxSettler` to handle various RPC responses.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
