### PR TITLE
Fix: Validate services instead of renaming

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -599,6 +599,13 @@ Get all services.
 ]
 ```
 
+**Response (Invalid service configuration - 500):**
+```json
+{
+  "error": "Some services are not valid. Please check the logs."
+}
+```
+
 ### `GET /api/v2/service/{service_config_id}`
 
 Get a specific service.

--- a/operate/cli.py
+++ b/operate/cli.py
@@ -294,7 +294,9 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
     def pause_all_services() -> None:
         service_manager = operate.service_manager()
         if not service_manager.validate_services():
-            logger.error("Some services are not valid. Only pausing the valid services.")
+            logger.error(
+                "Some services are not valid. Only pausing the valid services."
+            )
 
         service_config_ids = [
             i["service_config_id"] for i in operate.service_manager().json

--- a/operate/quickstart/run_service.py
+++ b/operate/quickstart/run_service.py
@@ -37,7 +37,7 @@ from operate.account.user import UserAccount
 from operate.constants import IPFS_ADDRESS, NO_STAKING_PROGRAM_ID, OPERATE_HOME
 from operate.data import DATA_DIR
 from operate.data.contracts.staking_token.contract import StakingTokenContract
-from operate.ledger.profiles import NO_STAKING_PROGRAM_ID, STAKING, get_staking_contract
+from operate.ledger.profiles import STAKING, get_staking_contract
 from operate.operate_types import (
     Chain,
     LedgerType,

--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -23,7 +23,6 @@ import asyncio
 import json
 import logging
 import os
-import time
 import traceback
 import typing as t
 from collections import Counter, defaultdict
@@ -69,13 +68,13 @@ from operate.operate_types import (
 )
 from operate.services.protocol import EthSafeTxBuilder, OnChainManager, StakingState
 from operate.services.service import (
-    SERVICE_CONFIG_VERSION,
     ChainConfig,
     Deployment,
     NON_EXISTENT_MULTISIG,
     NON_EXISTENT_TOKEN,
     OnChainData,
     SERVICE_CONFIG_PREFIX,
+    SERVICE_CONFIG_VERSION,
     Service,
 )
 from operate.services.utils.mech import deploy_mech


### PR DESCRIPTION
## Proposed changes

- [x] Not rename invalid services when loading them
- [x] `get services` endpoint now returns 500 if any service is found invalid.

## Changes to be done on FE

- Make `GET /api/v2/services` call **after** login and handle the 500 response if received. TBD with Iason that what message should be shown here and how.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
