### PR TITLE
feat: add Base chain mech marketplace support

### DIFF
--- a/operate/ledger/profiles.py
+++ b/operate/ledger/profiles.py
@@ -138,6 +138,10 @@ DEFAULT_PRIORITY_MECH = {  # maps mech marketplace address to its default priori
         "0xC05e7412439bD7e91730a6880E18d5D5873F632C",
         2182,
     ),
+    "0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020": (
+        "0x77af31De935740567Cf4fF1986D04B2c964A786a",
+        0,
+    ),
 }
 
 

--- a/operate/services/utils/mech.py
+++ b/operate/services/utils/mech.py
@@ -44,6 +44,13 @@ MECH_FACTORY_ADDRESS = {
             "Token": "0x31ffDC795FDF36696B8eDF7583A3D115995a45FA",
             "Nevermined": "0x65fd74C29463afe08c879a3020323DD7DF02DA57",
         },
+    },
+    Chain.BASE: {
+        "0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020": {
+            "Native": "0x2E008211f34b25A7d7c102403c6C2C3B665a1abe",
+            "Token": "0x97371B1C0cDA1D04dFc43DFb50a04645b7Bc9BEe",
+            "Nevermined": "0x847bBE8b474e0820215f818858e23F5f5591855A",
+        },
     }
 }
 


### PR DESCRIPTION
This PR adds support for Base chain mech marketplaces to olas-operate-middleware.

## Changes
- Add Base chain support to `MECH_FACTORY_ADDRESS` in `operate/services/utils/mech.py`
- Add Base marketplace to `DEFAULT_PRIORITY_MECH` in `operate/ledger/profiles.py`

## Details
- Base marketplace address: `0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020`
- Priority mech address: `0x77af31De935740567Cf4fF1986D04B2c964A786a`
- Service ID: 0 (placeholder)

This enables olas-operate-middleware to work with mech marketplaces on Base chain.