### PR TITLE
Fix: Claiming when not staked

### DIFF
--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -1908,10 +1908,11 @@ class ServiceManager:
             staking_program_id=current_staking_program,
         )
         if staking_contract is None:
-            raise RuntimeError(
+            self.logger.warning(
                 "No staking contract found for the "
                 f"{current_staking_program=}. Not claiming the rewards."
             )
+            return 0
 
         sftxb = self.get_eth_safe_tx_builder(ledger_config=ledger_config)
         if not sftxb.staking_rewards_claimable(


### PR DESCRIPTION
## Proposed changes

Fixes this error
```
2025-10-20T21:30:47.263Z cli: [2025-10-20 22:30:47,263][INFO] Error occured while claiming rewards
Traceback (most recent call last):
  File "operate/services/funding_manager.py", line 875, in funding_job
    await loop.run_in_executor(
  File "concurrent/futures/thread.py", line 58, in run
  File "operate/services/manage.py", line 1839, in claim_all_on_chain_from_safe
    self.claim_on_chain_from_safe(
  File "operate/services/manage.py", line 1876, in claim_on_chain_from_safe
    raise RuntimeError(
RuntimeError: No staking contract found for the current_staking_program=None. Not claiming the rewards.
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
