### PR TITLE
Fix: Make EOA draining tolerant of dust error

### DIFF
--- a/tests/test_services_funding.py
+++ b/tests/test_services_funding.py
@@ -594,9 +594,7 @@ class TestFunding(OnTestnet):
             ledger_api, ZERO_ADDRESS, dst_address
         )
         amount_transfer = master_safe_balance + master_eoa_balance
-        amount_transfer_native = (
-            master_safe_balance_native + master_eoa_balance_native - DUST[chain]
-        )
+        amount_transfer_native = master_safe_balance_native + master_eoa_balance_native
         response = client.post(
             url="/api/wallet/withdraw",
             json={


### PR DESCRIPTION
## Proposed changes

Fixes this error
```
Traceback (most recent call last):
  File "operate/cli.py", line 891, in _wallet_withdraw
    txs = wallet.transfer_from_safe_then_eoa(
  File "operate/wallet/master.py", line 491, in transfer_from_safe_then_eoa
    raise InsufficientFundsException(
operate.wallet.master.InsufficientFundsException: Cannot transfer 10476096870264158409 asset 0x0000000000000000000000000000000000000000 units to 0xFD19fe216cF6699eBdFD8f038a74c9b24E23A7b7 on chain Gnosis. Balance of master safe is 9726759386586733447. Balance of master eoa is 749142837233943446.
```

This was happening because when `GET /api/wallet/withdraw` API is called with the exact sum of the Master Safe native balance and the Master EOA native balance, first some balance is exhausted for the ERC20 transfers, and by the time we reach `transfer_from_safe_then_eoa` for the final native transfer, not enough funds are left to transfer the original sum.
This PR makes the function tolerant of the DUST amount and makes it work similarly to `_transfer_from_eoa`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
