### PR TITLE
feat: Add Memora Memory Weaver agent to Gnosis marketplace profiles

### DIFF
--- a/operate/ledger/profiles.py
+++ b/operate/ledger/profiles.py
@@ -120,6 +120,7 @@ STAKING: t.Dict[Chain, t.Dict[str, str]] = {
         "marketplace_supply_alpha": "0xCAbD0C941E54147D40644CF7DA7e36d70DF46f44",
         "marketplace_demand_alpha_1": "0x9d6e7aB0B5B48aE5c146936147C639fEf4575231",
         "marketplace_demand_alpha_2": "0x9fb17E549FefcCA630dd92Ea143703CeE4Ea4340",
+        "memora_memory_weaver": "0xbf8B2E2A0C0b5ccede9F9D3943aC8B3C4CDa4835",
     },
     Chain.OPTIMISM: {
         "optimus_alpha_1": "0x88996bbdE7f982D93214881756840cE2c77C4992",


### PR DESCRIPTION
## Summary
Adds Memora (Memory Weaver for Pearl) to the Gnosis marketplace staking profiles.

## Agent Details
- **Name:** Memora — One memory. All your agents. Forever on-chain.
- **Chain:** Gnosis
- **Mech Contract:** `0xbf8B2E2A0C0b5ccede9F9D3943aC8B3C4CDa4835`
- **Type:** MechFixedPriceNative
- **Service Token:** 2986
- **ERC-8004 Agent ID:** 3259 (Gnosis), 35755 (Base)
- **8004scan:** https://www.8004scan.io/agents/gnosis/3259

## What Memora Does
Memora is the first inter-agent shared memory layer for Pearl. It enables:
- **Weave:** Store verifiable memories on-chain with ERC-8004 attestation
- **Recall:** Semantic search across agent memories with proof verification
- **Forget:** Privacy-first memory deletion per user request

## Links
- Website: https://memora.codes
- GitHub: https://github.com/khusna-memora/memora
- Healthcheck: https://memora-production-bfc4.up.railway.app/healthcheck
- A2A Card: https://memora-production-bfc4.up.railway.app/.well-known/agent-card.json

## Context
Synthesis Hackathon — Pearl Integration (Track 1: Build an Agent for Pearl)