### PR TITLE
ci: reduce platform matrix, make integration tests strict

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -65,14 +65,23 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.14"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.14"
 
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -88,8 +97,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.14"
 
@@ -105,9 +114,10 @@ jobs:
           fail_ci_if_error: false
 
   integration-tests:
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - linter_checks
+      - unit-tests
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -131,8 +141,8 @@ jobs:
       POLYGON_TESTNET_RPC: ${{ secrets.POLYGON_TESTNET_RPC }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

- Reduce `unit-tests` matrix from **15 to 9 cells**: full Python coverage (3.10–3.14) on Ubuntu, min/max only on macOS and Windows — frees runner slots for other repos
- Make `integration-tests` strict (`continue-on-error: False`) so failures block the workflow
- Gate `integration-tests` on `unit-tests` passing — no point burning integration resources when unit tests are broken
- Bump `actions/checkout` and `actions/setup-python` from v3 to v4

| OS | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
|---|---|---|---|---|---|
| ubuntu-latest | ✅ | ✅ | ✅ | ✅ | ✅ |
| macos-latest | ✅ | | | | ✅ |
| windows-latest | ✅ | | | | ✅ |

**macOS/Windows runners: 10 → 4** (frees 6 slots per CI run)

Mirrors the approach in valory-xyz/open-aea#869.

## Test plan

- [ ] CI creates exactly 9 `unit-tests` cells (not 15)
- [ ] macOS shows only 3.10 and 3.14
- [ ] Windows shows only 3.10 and 3.14
- [ ] `integration-tests` waits for `unit-tests` to pass
- [ ] Integration test failure blocks the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)