### PR TITLE
[FEATURE] Add ENABLE_PARENT_WATCHDOG env var for headless deployment

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -499,12 +499,12 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             app._server.should_exit = True  # pylint: disable=protected-access
             logger.info("App stopped due to parent death.")
 
-        if os.environ.get("DISABLE_PARENT_WATCHDOG", "0") != "1":
+        if os.environ.get("ENABLE_PARENT_WATCHDOG", "1") == "1":
             watchdog = ParentWatchdog(on_parent_exit=stop_app)
             watchdog.start()
         else:
             watchdog = None
-            logger.info("ParentWatchdog disabled via DISABLE_PARENT_WATCHDOG=1")
+            logger.info("ParentWatchdog disabled via ENABLE_PARENT_WATCHDOG=0")
 
         yield  # --- app is running ---
 

--- a/operate/cli.py
+++ b/operate/cli.py
@@ -499,16 +499,21 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             app._server.should_exit = True  # pylint: disable=protected-access
             logger.info("App stopped due to parent death.")
 
-        watchdog = ParentWatchdog(on_parent_exit=stop_app)
-        watchdog.start()
+        if os.environ.get("DISABLE_PARENT_WATCHDOG", "0") != "1":
+            watchdog = ParentWatchdog(on_parent_exit=stop_app)
+            watchdog.start()
+        else:
+            watchdog = None
+            logger.info("ParentWatchdog disabled via DISABLE_PARENT_WATCHDOG=1")
 
         yield  # --- app is running ---
 
         with suppress(Exception):
             cancel_funding_job()
 
-        with suppress(Exception):
-            await watchdog.stop()
+        if watchdog is not None:
+            with suppress(Exception):
+                await watchdog.stop()
 
     app = FastAPI(lifespan=lifespan)
 

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -499,17 +499,17 @@ class TestCreateAppInfra:
 
         assert app._server.should_exit is True
 
-    # ── DISABLE_PARENT_WATCHDOG ──────────────────────────────────────────────
+    # ── ENABLE_PARENT_WATCHDOG ───────────────────────────────────────────────
 
     def test_lifespan_skips_watchdog_when_disabled(self) -> None:
-        """When DISABLE_PARENT_WATCHDOG=1 the watchdog must not be created."""
+        """When ENABLE_PARENT_WATCHDOG=0 the watchdog must not be created."""
         m = _make_mock_operate()
         ua = MagicMock()
         ua.is_valid.return_value = True
         m.user_account = ua
 
         stack, app, mock_wd, mock_wd_cls = _open_app(
-            m, env={"DISABLE_PARENT_WATCHDOG": "1"}
+            m, env={"ENABLE_PARENT_WATCHDOG": "0"}
         )
         with stack:
             with TestClient(app, raise_server_exceptions=False):
@@ -520,7 +520,7 @@ class TestCreateAppInfra:
         mock_wd.stop.assert_not_called()
 
     def test_lifespan_starts_watchdog_when_env_unset(self) -> None:
-        """When DISABLE_PARENT_WATCHDOG is absent the watchdog must start."""
+        """When ENABLE_PARENT_WATCHDOG is absent the watchdog must start."""
         m = _make_mock_operate()
         ua = MagicMock()
         ua.is_valid.return_value = True
@@ -535,15 +535,15 @@ class TestCreateAppInfra:
         mock_wd.start.assert_called()
         mock_wd.stop.assert_called()
 
-    def test_lifespan_starts_watchdog_when_env_is_zero(self) -> None:
-        """When DISABLE_PARENT_WATCHDOG=0 the watchdog must still start."""
+    def test_lifespan_starts_watchdog_when_env_is_one(self) -> None:
+        """When ENABLE_PARENT_WATCHDOG=1 the watchdog must still start."""
         m = _make_mock_operate()
         ua = MagicMock()
         ua.is_valid.return_value = True
         m.user_account = ua
 
         stack, app, mock_wd, mock_wd_cls = _open_app(
-            m, env={"DISABLE_PARENT_WATCHDOG": "0"}
+            m, env={"ENABLE_PARENT_WATCHDOG": "1"}
         )
         with stack:
             with TestClient(app, raise_server_exceptions=False):

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -499,6 +499,60 @@ class TestCreateAppInfra:
 
         assert app._server.should_exit is True
 
+    # ── DISABLE_PARENT_WATCHDOG ──────────────────────────────────────────────
+
+    def test_lifespan_skips_watchdog_when_disabled(self) -> None:
+        """When DISABLE_PARENT_WATCHDOG=1 the watchdog must not be created."""
+        m = _make_mock_operate()
+        ua = MagicMock()
+        ua.is_valid.return_value = True
+        m.user_account = ua
+
+        stack, app, mock_wd, mock_wd_cls = _open_app(
+            m, env={"DISABLE_PARENT_WATCHDOG": "1"}
+        )
+        with stack:
+            with TestClient(app, raise_server_exceptions=False):
+                pass
+
+        mock_wd_cls.assert_not_called()
+        mock_wd.start.assert_not_called()
+        mock_wd.stop.assert_not_called()
+
+    def test_lifespan_starts_watchdog_when_env_unset(self) -> None:
+        """When DISABLE_PARENT_WATCHDOG is absent the watchdog must start."""
+        m = _make_mock_operate()
+        ua = MagicMock()
+        ua.is_valid.return_value = True
+        m.user_account = ua
+
+        stack, app, mock_wd, mock_wd_cls = _open_app(m)
+        with stack:
+            with TestClient(app, raise_server_exceptions=False):
+                pass
+
+        mock_wd_cls.assert_called_once()
+        mock_wd.start.assert_called()
+        mock_wd.stop.assert_called()
+
+    def test_lifespan_starts_watchdog_when_env_is_zero(self) -> None:
+        """When DISABLE_PARENT_WATCHDOG=0 the watchdog must still start."""
+        m = _make_mock_operate()
+        ua = MagicMock()
+        ua.is_valid.return_value = True
+        m.user_account = ua
+
+        stack, app, mock_wd, mock_wd_cls = _open_app(
+            m, env={"DISABLE_PARENT_WATCHDOG": "0"}
+        )
+        with stack:
+            with TestClient(app, raise_server_exceptions=False):
+                pass
+
+        mock_wd_cls.assert_called_once()
+        mock_wd.start.assert_called()
+        mock_wd.stop.assert_called()
+
     # ── middleware exception handler ───────────────────────────────────────────
 
     def test_middleware_handles_unhandled_exception(self) -> None:


### PR DESCRIPTION
## Description

Adds an `ENABLE_PARENT_WATCHDOG` environment variable that allows the middleware to run headless in Docker/container environments without the Pearl desktop app.

## Problem

The `ParentWatchdog` in the FastAPI lifespan monitors the parent process and shuts down the daemon when `os.getppid() == 1` (parent died / reparented to init). This is designed for Pearl, where the middleware should exit if the Electron app closes. In Docker containers, the daemon always runs as PID 1 or its parent is always PID 1, so the watchdog immediately kills the process — making it impossible to run the middleware headless.

## Changes

- In `operate/cli.py`, gated `ParentWatchdog` creation on `os.environ.get("ENABLE_PARENT_WATCHDOG", "1") == "1"`
- Default behavior (watchdog enabled) is unchanged
- Headless deployments opt out with `ENABLE_PARENT_WATCHDOG=0`; a log message is emitted when the watchdog is skipped
- Updated the 3 unit tests to cover disabled, unset, and explicitly-enabled scenarios

## Usage

```bash
ENABLE_PARENT_WATCHDOG=0 operate daemon --host=0.0.0.0 --port=8000
```

Or in a Dockerfile:

```dockerfile
ENV ENABLE_PARENT_WATCHDOG=0
CMD ["operate", "daemon", "--host=0.0.0.0", "--port=8000"]
```

## Testing

- [x] 3 updated unit tests (`tests/test_cli_unit.py`)
- [x] All existing unit tests pass (`tox -e unit-tests`)
- [x] All linters pass (black, isort, flake8, pylint 10.00/10, mypy, bandit)
- [x] Manually tested in Docker on both x86_64 and aarch64

## Checklist

- [x] Code follows style guidelines
- [x] All tests pass
- [x] No new warnings generated
- [x] Minimal change — a handful of lines in `cli.py`, plus the tests