### PR TITLE
Fix CI timing out

### DIFF
--- a/tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[LiFiProvider].yaml
+++ b/tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[LiFiProvider].yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - chainlist.org
+      User-Agent:
+      - Python-urllib/3.14
+    method: GET
+    uri: https://chainlist.org/rpcs.json
+  response:
+    body:
+      string: 'error code: 1010'
+    headers:
+      CF-RAY:
+      - 9f065741199f49eb-MRS
+      Cache-Control:
+      - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection:
+      - close
+      Content-Length:
+      - '16'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 22 Apr 2026 17:27:43 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:01 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Referrer-Policy:
+      - same-origin
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=n2Tdxyd75rD%2FoCmPa9a7zcbkB94t3taFfgBQEmevM%2BHy7gHFHMIAquhEFnDQeluZq6Syjd7hhGMQV813vToaUZlgeI5ifz1HK1oSUufvMotgTvdENJz5EgZu7VLKMBIzPpE9zwIvmAIwb3ny"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfEdge;dur=2,cfOrigin;dur=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[RelayProvider].yaml
+++ b/tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[RelayProvider].yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - chainlist.org
+      User-Agent:
+      - Python-urllib/3.14
+    method: GET
+    uri: https://chainlist.org/rpcs.json
+  response:
+    body:
+      string: 'error code: 1010'
+    headers:
+      CF-RAY:
+      - 9f06573b7edbb24a-MRS
+      Cache-Control:
+      - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection:
+      - close
+      Content-Length:
+      - '16'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 22 Apr 2026 17:27:42 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:01 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Referrer-Policy:
+      - same-origin
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=BKUTnvzYqZTZ39UFbwu12%2F7nqXuZPfRLioYQYLGN0OwtZQHpyofVplhzLovdkHqG7pSx5njvPsfgRXJFFCv%2FLXSVYezJj0WBA2xDm8g7fO0UF29GMTcF1LAYOkVWuAr%2F1XvU5nyel0hbsfnt"}]}'
+      Server:
+      - cloudflare
+      Server-Timing:
+      - cfEdge;dur=1,cfOrigin;dur=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/test_bridge_providers.py
+++ b/tests/test_bridge_providers.py
@@ -59,6 +59,7 @@ from operate.ledger.profiles import OLAS
 from operate.operate_types import Chain, ChainAmounts, LedgerType
 from operate.serialization import BigInt
 
+from tests.conftest import OnTestnet
 from tests.constants import OPERATE_TEST, RUNNING_IN_CI
 
 TRANSFER_TOPIC = Web3.keccak(text="Transfer(address,address,uint256)").to_0x_hex()
@@ -565,7 +566,7 @@ def get_transfer_amount(
 
 
 @pytest.mark.integration
-class TestNativeBridgeProvider:
+class TestNativeBridgeProvider(OnTestnet):
     """Tests for bridge.providers.NativeBridgeProvider class."""
 
     @pytest.mark.flaky(reruns=3, reruns_delay=30)
@@ -769,7 +770,7 @@ class TestNativeBridgeProvider:
 
 
 @pytest.mark.integration
-class TestProvider:
+class TestProvider(OnTestnet):
     """Tests for bridge.providers.Provider class."""
 
     @pytest.mark.vcr


### PR DESCRIPTION
This pull request updates the test suite for bridge providers by introducing a new base class for testnet-specific tests and adding new VCR cassettes for provider tests. The main changes are the use of the `OnTestnet` base class for relevant test classes and the addition of HTTP interaction recordings for `LiFiProvider` and `RelayProvider`.

**Test infrastructure improvements:**

* Updated `TestNativeBridgeProvider` and `TestProvider` classes in `tests/test_bridge_providers.py` to inherit from the new `OnTestnet` base class, ensuring these tests only run on testnet environments. [[1]](diffhunk://#diff-b4c48c56248e241fa0e1b31ad6058fb782a67447a52b010ebcf91c66e5123c66L568-R569) [[2]](diffhunk://#diff-b4c48c56248e241fa0e1b31ad6058fb782a67447a52b010ebcf91c66e5123c66L772-R773)
* Imported `OnTestnet` from `tests.conftest` to support the new test class inheritance.

**Test coverage enhancements:**

* Added VCR cassette `tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[LiFiProvider].yaml` to record and replay HTTP interactions for the `LiFiProvider` test. ([tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[LiFiProvider].yamlR1-R48](diffhunk://#diff-39ee116394ded57a80c3567493075b7f5bfa932488b32653f7aa34a78893a52fR1-R48))
* Added VCR cassette `tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[RelayProvider].yaml` to record and replay HTTP interactions for the `RelayProvider` test. ([tests/cassettes/test_bridge_providers/TestProvider.test_bridge_zero[RelayProvider].yamlR1-R48](diffhunk://#diff-6c9f8e1f9d39559c2c3f256278496139505b39357a742e3f67295a934e755f24R1-R48))