### PR TITLE
chore(deps): bump open-autonomy to 0.21.19, open-aea to 2.2.1, tomte to 0.6.5

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt-get autoremove
         sudo apt-get autoclean
-        pip install tomte[tox]==0.6.1
+        pip install tomte[tox]==0.6.5
         pip install --user --upgrade setuptools
         sudo npm install -g markdown-spellcheck
     - name: All pre-test checks
@@ -77,7 +77,7 @@ jobs:
         env:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.6.5
           tox -e unit-tests
 
   coverage:
@@ -99,7 +99,7 @@ jobs:
         env:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.6.5
           tox -e unit-tests-coverage
 
       - name: Upload coverage to Codecov
@@ -149,5 +149,5 @@ jobs:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
           PYTEST_XDIST_WORKERS: "8"
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.6.5
           tox -e integration-tests

--- a/operate/pearl.py
+++ b/operate/pearl.py
@@ -38,7 +38,6 @@ from aea.crypto.registries.base import *
 from aea.mail.base_pb2 import DESCRIPTOR
 from aea_ledger_cosmos.cosmos import *  # noqa
 from aea_ledger_ethereum.ethereum import *
-from aea_ledger_ethereum_flashbots.ethereum_flashbots import *  # noqa
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
 from multiaddr.codecs.idna import to_bytes as _
 from multiaddr.codecs.uint16be import to_bytes as _

--- a/operate/services/deployment_runner.py
+++ b/operate/services/deployment_runner.py
@@ -910,7 +910,6 @@ class HostPythonHostDeploymentRunner(BaseDeploymentRunner):
                 "install",
                 f"open-autonomy[all]=={autonomy_version}",
                 f"open-aea-ledger-ethereum=={aea_version}",
-                f"open-aea-ledger-ethereum-flashbots=={aea_version}",
                 f"open-aea-ledger-cosmos=={aea_version}",
                 # Install tendermint dependencies
                 "flask",

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -102,6 +102,23 @@ class StakingState(Enum):
     EVICTED = 2
 
 
+def _normalize_multisend_tx_data(data: t.Any) -> bytes:
+    """Coerce a multisend ``tx["data"]`` value to bytes.
+
+    open-autonomy 0.21.19 inlined the multisend encoder and dropped its
+    ``HexBytes(data)`` wrapper, so ``encode_data`` now requires strict
+    ``bytes`` — pre-0.21.19 it silently accepted hex strings via the
+    HexBytes coercion. Call sites in this file historically passed a hex
+    string slice (``encode_abi(...)[2:]``); this helper keeps the call
+    sites readable while ensuring the value reaches multisend as bytes.
+    """
+    if isinstance(data, (bytes, bytearray)):
+        return bytes(data)
+    if isinstance(data, str):
+        return bytes.fromhex(data[2:] if data[:2].lower() == "0x" else data)
+    raise TypeError(f"Unsupported multisend tx data type: {type(data).__name__}")
+
+
 class GnosisSafeTransaction:
     """Safe transaction"""
 
@@ -121,7 +138,9 @@ class GnosisSafeTransaction:
 
     def add(self, tx: t.Dict) -> "GnosisSafeTransaction":
         """Add a transaction"""
-        self._txs.append(tx)
+        self._txs.append(
+            {**tx, "data": _normalize_multisend_tx_data(tx.get("data", b""))}
+        )
         return self
 
     def build(self) -> t.Dict:
@@ -1673,9 +1692,11 @@ class EthSafeTxBuilder(_ChainUtil):
         txs.append(
             {
                 "to": token,
-                "data": erc20_instance.encode_abi(
-                    abi_element_identifier="transfer",
-                    args=[to, amount],
+                "data": _normalize_multisend_tx_data(
+                    erc20_instance.encode_abi(
+                        abi_element_identifier="transfer",
+                        args=[to, amount],
+                    )
                 ),
                 "operation": MultiSendOperation.CALL,
                 "value": 0,

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -102,23 +102,6 @@ class StakingState(Enum):
     EVICTED = 2
 
 
-def _normalize_multisend_tx_data(data: t.Any) -> bytes:
-    """Coerce a multisend ``tx["data"]`` value to bytes.
-
-    open-autonomy 0.21.19 inlined the multisend encoder and dropped its
-    ``HexBytes(data)`` wrapper, so ``encode_data`` now requires strict
-    ``bytes`` — pre-0.21.19 it silently accepted hex strings via the
-    HexBytes coercion. Call sites in this file historically passed a hex
-    string slice (``encode_abi(...)[2:]``); this helper keeps the call
-    sites readable while ensuring the value reaches multisend as bytes.
-    """
-    if isinstance(data, (bytes, bytearray)):
-        return bytes(data)
-    if isinstance(data, str):
-        return bytes.fromhex(data[2:] if data[:2].lower() == "0x" else data)
-    raise TypeError(f"Unsupported multisend tx data type: {type(data).__name__}")
-
-
 class GnosisSafeTransaction:
     """Safe transaction"""
 
@@ -138,9 +121,7 @@ class GnosisSafeTransaction:
 
     def add(self, tx: t.Dict) -> "GnosisSafeTransaction":
         """Add a transaction"""
-        self._txs.append(
-            {**tx, "data": _normalize_multisend_tx_data(tx.get("data", b""))}
-        )
+        self._txs.append(tx)
         return self
 
     def build(self) -> t.Dict:
@@ -1692,11 +1673,13 @@ class EthSafeTxBuilder(_ChainUtil):
         txs.append(
             {
                 "to": token,
-                "data": _normalize_multisend_tx_data(
+                # OA 0.21.19's multisend encoder requires strict bytes;
+                # encode_abi returns a 0x-prefixed hex string in web3 v7.
+                "data": bytes.fromhex(
                     erc20_instance.encode_abi(
                         abi_element_identifier="transfer",
                         args=[to, amount],
-                    )
+                    )[2:]
                 ),
                 "operation": MultiSendOperation.CALL,
                 "value": 0,

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -58,7 +58,6 @@ from autonomy.chain.tx import TxSettler
 from autonomy.cli.helpers.chain import MintHelper, OnChainHelper
 from autonomy.cli.helpers.chain import ServiceHelper as ServiceManager
 from eth_utils import to_bytes
-from hexbytes import HexBytes
 from web3.contract import Contract
 from web3.types import TxReceipt
 
@@ -969,7 +968,7 @@ class _ChainUtil:
                 "operation": MultiSendOperation.CALL,
                 "to": multisig,
                 "value": 0,
-                "data": HexBytes(txd[2:]),
+                "data": bytes.fromhex(txd[2:]),
             }
         )
         multisend_txd = registry_contracts.multisend.get_tx_data(  # type: ignore
@@ -2044,13 +2043,11 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
         txs.append(
             {
                 "to": multisig_address,
-                "data": HexBytes(
-                    bytes.fromhex(
-                        multisig_instance.encode_abi(
-                            abi_element_identifier="addOwnerWithThreshold",
-                            args=[_owner, 1],
-                        )[2:]
-                    )
+                "data": bytes.fromhex(
+                    multisig_instance.encode_abi(
+                        abi_element_identifier="addOwnerWithThreshold",
+                        args=[_owner, 1],
+                    )[2:]
                 ),
                 "operation": MultiSendOperation.CALL,
                 "value": 0,
@@ -2060,13 +2057,11 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
     txs.append(
         {
             "to": multisig_address,
-            "data": HexBytes(
-                bytes.fromhex(
-                    multisig_instance.encode_abi(
-                        abi_element_identifier="removeOwner",
-                        args=[new_owners[0], master_safe, 1],
-                    )[2:]
-                )
+            "data": bytes.fromhex(
+                multisig_instance.encode_abi(
+                    abi_element_identifier="removeOwner",
+                    args=[new_owners[0], master_safe, 1],
+                )[2:]
             ),
             "operation": MultiSendOperation.CALL,
             "value": 0,
@@ -2076,13 +2071,11 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
     txs.append(
         {
             "to": multisig_address,
-            "data": HexBytes(
-                bytes.fromhex(
-                    multisig_instance.encode_abi(
-                        abi_element_identifier="changeThreshold",
-                        args=[threshold],
-                    )[2:]
-                )
+            "data": bytes.fromhex(
+                multisig_instance.encode_abi(
+                    abi_element_identifier="changeThreshold",
+                    args=[threshold],
+                )[2:]
             ),
             "operation": MultiSendOperation.CALL,
             "value": 0,

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -1404,7 +1404,7 @@ class EthSafeTxBuilder(_ChainUtil):
 
         return {
             "to": self.service_manager_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1426,7 +1426,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": erc20_contract,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1442,7 +1442,7 @@ class EthSafeTxBuilder(_ChainUtil):
         return {
             "from": self.safe,
             "to": self.service_manager_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": cost_of_bond,
         }
@@ -1466,7 +1466,7 @@ class EthSafeTxBuilder(_ChainUtil):
         return {
             "from": self.safe,
             "to": self.service_manager_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": cost_of_bond,
         }
@@ -1554,7 +1554,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         deploy_message = {
             "to": self.service_manager_address,
-            "data": deploy_data[2:],
+            "data": bytes.fromhex(deploy_data[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1616,7 +1616,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         approve_hash_message = {
             "to": safe_b_address,
-            "data": approve_hash_data[2:],
+            "data": bytes.fromhex(approve_hash_data[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1639,7 +1639,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         exec_message = {
             "to": safe_b_address,
-            "data": exec_data[2:],
+            "data": bytes.fromhex(exec_data[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1669,18 +1669,15 @@ class EthSafeTxBuilder(_ChainUtil):
             contract_address=token,
         )
 
+        txd = erc20_instance.encode_abi(
+            abi_element_identifier="transfer",
+            args=[to, amount],
+        )
         txs = []
         txs.append(
             {
                 "to": token,
-                # OA 0.21.19's multisend encoder requires strict bytes;
-                # encode_abi returns a 0x-prefixed hex string in web3 v7.
-                "data": bytes.fromhex(
-                    erc20_instance.encode_abi(
-                        abi_element_identifier="transfer",
-                        args=[to, amount],
-                    )[2:]
-                ),
+                "data": bytes.fromhex(txd[2:]),
                 "operation": MultiSendOperation.CALL,
                 "value": 0,
             }
@@ -1712,7 +1709,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         approve_hash_message = {
             "to": safe_b_address,
-            "data": approve_hash_data[2:],
+            "data": bytes.fromhex(approve_hash_data[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1735,7 +1732,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         exec_message = {
             "to": safe_b_address,
-            "data": exec_data[2:],
+            "data": bytes.fromhex(exec_data[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1750,7 +1747,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": self.service_manager_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1763,7 +1760,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": self.service_manager_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1786,7 +1783,7 @@ class EthSafeTxBuilder(_ChainUtil):
         return {
             "from": self.safe,
             "to": self.contracts["service_registry"],
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1806,7 +1803,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": staking_contract,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1835,7 +1832,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": staking_contract,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1856,7 +1853,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": staking_contract,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1903,7 +1900,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": self.contracts["recovery_module"],
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -1925,7 +1922,7 @@ class EthSafeTxBuilder(_ChainUtil):
         )
         return {
             "to": safe_address,
-            "data": txd[2:],
+            "data": bytes.fromhex(txd[2:]),
             "operation": MultiSendOperation.CALL,
             "value": 0,
         }
@@ -2115,7 +2112,7 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
     )
     approve_hash_message = {
         "to": multisig_address,
-        "data": approve_hash_data[2:],
+        "data": bytes.fromhex(approve_hash_data[2:]),
         "operation": MultiSendOperation.CALL,
         "value": 0,
     }

--- a/poetry.lock
+++ b/poetry.lock
@@ -4750,4 +4750,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.15,>=3.10"
-content-hash = "2efc72f3b33fdd7031a7b510cb8cf4ede6de4b083b576dc04fdb21be031d5e2a"
+content-hash = "bf785c3612714e9d06be4da18089b5e56870ead07c102ede847f46bcb714e8f5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -279,6 +279,18 @@ cffi = [
 ]
 
 [[package]]
+name = "asn1crypto"
+version = "1.4.0"
+description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "asn1crypto-1.4.0-py2.py3-none-any.whl", hash = "sha256:4bcdf33c861c7d40bdcd74d8e4dd7661aac320fcdf40b9a3f95b4ee12fde2fa8"},
+    {file = "asn1crypto-1.4.0.tar.gz", hash = "sha256:f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c"},
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -304,24 +316,12 @@ files = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-description = "Function decoration for backoff and retry"
-optional = false
-python-versions = ">=3.7,<4.0"
-groups = ["main"]
-files = [
-    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
-    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
-]
-
-[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
 optional = false
 python-versions = "<3.11,>=3.8"
-groups = ["development"]
+groups = ["main", "development"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
@@ -1418,14 +1418,14 @@ websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
 name = "ecdsa"
-version = "0.16.1"
+version = "0.19.2"
 description = "ECDSA cryptographic signature library (pure python)"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.6"
 groups = ["main"]
 files = [
-    {file = "ecdsa-0.16.1-py2.py3-none-any.whl", hash = "sha256:881fa5e12bb992972d3d1b3d4dfbe149ab76a89f13da02daa5ea1ec7dea6e747"},
-    {file = "ecdsa-0.16.1.tar.gz", hash = "sha256:cfc046a2ddd425adbd1a78b3c46f0d1325c657811c0f45ecc3a0a6236c1e50ff"},
+    {file = "ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399"},
+    {file = "ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930"},
 ]
 
 [package.dependencies]
@@ -1869,47 +1869,6 @@ protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4
 grpc = ["grpcio (>=1.44.0,<2.0.0)"]
 
 [[package]]
-name = "gql"
-version = "3.5.0"
-description = "GraphQL client for Python"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "gql-3.5.0-py2.py3-none-any.whl", hash = "sha256:70dda5694a5b194a8441f077aa5fb70cc94e4ec08016117523f013680901ecb7"},
-    {file = "gql-3.5.0.tar.gz", hash = "sha256:ccb9c5db543682b28f577069950488218ed65d4ac70bb03b6929aaadaf636de9"},
-]
-
-[package.dependencies]
-anyio = ">=3.0,<5"
-backoff = ">=1.11.1,<3.0"
-graphql-core = ">=3.2,<3.3"
-yarl = ">=1.6,<2.0"
-
-[package.extras]
-aiohttp = ["aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\""]
-all = ["aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "websockets (>=10,<12)"]
-botocore = ["botocore (>=1.21,<2)"]
-dev = ["aiofiles", "aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "black (==22.3.0)", "botocore (>=1.21,<2)", "check-manifest (>=0.42,<1)", "flake8 (==3.8.1)", "httpx (>=0.23.1,<1)", "isort (==4.3.21)", "mock (==4.0.2)", "mypy (==0.910)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "sphinx (>=5.3.0,<6)", "sphinx-argparse (==0.2.5)", "sphinx-rtd-theme (>=0.4,<1)", "types-aiofiles", "types-mock", "types-requests", "vcrpy (==4.4.0)", "websockets (>=10,<12)"]
-httpx = ["httpx (>=0.23.1,<1)"]
-requests = ["requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)"]
-test = ["aiofiles", "aiohttp (>=3.8.0,<4) ; python_version <= \"3.11\"", "aiohttp (>=3.9.0b0,<4) ; python_version > \"3.11\"", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "vcrpy (==4.4.0)", "websockets (>=10,<12)"]
-test-no-transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.4.0)"]
-websockets = ["websockets (>=10,<12)"]
-
-[[package]]
-name = "graphql-core"
-version = "3.2.7"
-description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
-optional = false
-python-versions = "<4,>=3.7"
-groups = ["main"]
-files = [
-    {file = "graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0"},
-    {file = "graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c"},
-]
-
-[[package]]
 name = "grpcio"
 version = "1.78.0"
 description = "HTTP/2-based RPC framework"
@@ -2137,22 +2096,6 @@ files = [
 ]
 
 [[package]]
-name = "ipfshttpclient"
-version = "0.8.0a2"
-description = "Python IPFS HTTP CLIENT library"
-optional = false
-python-versions = ">=3.6.2,!=3.7.0,!=3.7.1"
-groups = ["main"]
-files = [
-    {file = "ipfshttpclient-0.8.0a2-py3-none-any.whl", hash = "sha256:ce6bac0e3963c4ced74d7eb6978125362bb05bbe219088ca48f369ce14d3cc39"},
-    {file = "ipfshttpclient-0.8.0a2.tar.gz", hash = "sha256:0d80e95ee60b02c7d414e79bf81a36fc3c8fbab74265475c52f70b2620812135"},
-]
-
-[package.dependencies]
-multiaddr = ">=0.0.7"
-requests = ">=2.11"
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 description = "Safely pass data to untrusted environments and back."
@@ -2347,17 +2290,6 @@ files = [
     {file = "markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e"},
     {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
     {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
-]
-
-[[package]]
-name = "morphys"
-version = "1.0"
-description = "Smart conversions between unicode and bytes types for common cases"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "morphys-1.0-py2.py3-none-any.whl", hash = "sha256:76d6dbaa4d65f597e59d332c81da786d83e4669387b9b2a750cfec74e7beec20"},
 ]
 
 [[package]]
@@ -2566,168 +2498,125 @@ files = [
 
 [[package]]
 name = "open-aea"
-version = "2.1.0"
-description = "Open Autonomous Economic Agent framework (without vendor lock-in)"
+version = "2.2.1"
+description = "Open AEA Framework"
 optional = false
-python-versions = ">=3.10"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea-2.1.0-py3-none-any.whl", hash = "sha256:265f12f47fff15b68cb8250772b662c07aea1ed83375d1026af5bba6b411b49b"},
-    {file = "open_aea-2.1.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:a36db8ac275efa75e177de4b9c27233a20615724aa02d6690e95cc9c45034c79"},
-    {file = "open_aea-2.1.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:f2f8ce89ae10d717d139af659d244b2978bf41fb6e0f2ebfd105ed7860fe1af6"},
-    {file = "open_aea-2.1.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b6b90c8a06e0ca53d8a86d7880f207b3fc66c10020252feb6a3ea5c70bf901a9"},
-    {file = "open_aea-2.1.0-py3-none-win32.whl", hash = "sha256:c67fa0b77fe1195376078cd1bf2b64ec77b82505e83e610a6ae1ab884043dfea"},
-    {file = "open_aea-2.1.0-py3-none-win_amd64.whl", hash = "sha256:cace2e62682aa6f4bcf023306e878917b4008ab7a9d9f30c12adbbcc1da7900c"},
-    {file = "open_aea-2.1.0.tar.gz", hash = "sha256:b5a40bcc7fbc6a78ed9a42a1aea0855d736849f9327a1a417fa136a0ab195cae"},
+    {file = "open_aea-2.2.1-py3-none-any.whl", hash = "sha256:741910443d4bf22f73b0e7ec8860903d0a6cf1a8ffc66aae9fd634c5fd7b6500"},
+    {file = "open_aea-2.2.1.tar.gz", hash = "sha256:3cb357977109103622ceed1b0badfbdcb10afc1c105bb91ca5111026842cf966"},
 ]
 
 [package.dependencies]
-base58 = ">=1.0.3,<3.0.0"
-click = {version = ">=8.1.0,<8.4.0", optional = true, markers = "extra == \"all\""}
-coverage = {version = ">=6.4.4,<8.0.0", optional = true, markers = "extra == \"all\""}
-ecdsa = ">=0.15,<0.17.0"
-jsonschema = ">=4.3.0,<4.24.0"
-morphys = ">=1.0"
-packaging = "26"
-protobuf = ">=5,<6"
-py-multibase = ">=1.0.0"
-py-multicodec = ">=0.2.0"
-pymultihash = "0.8.2"
-pytest = {version = ">=8.2,<10", optional = true, markers = "extra == \"all\""}
-python-dotenv = ">=0.14.0,<1.0.1"
-pyyaml = [
-    {version = ">=6.0.1,<7"},
-    {version = ">=6.0.1,<7", optional = true, markers = "extra == \"all\""},
-]
-requests = ">=2.32.5,<3"
-semver = ">=2.9.1,<3.0.0"
+click = {version = ">=8.1.0,<8.4.0", optional = true, markers = "extra == \"cli\" or extra == \"test-tools\" or extra == \"all\""}
+coverage = {version = ">=6.4.4,<9", optional = true, markers = "extra == \"cli\" or extra == \"test-tools\" or extra == \"all\""}
+packaging = {version = ">=22.0,<27", optional = true, markers = "extra == \"cli\" or extra == \"test-tools\" or extra == \"all\""}
+protobuf = ">=5,<7"
+pytest = {version = ">=7.0,<10", optional = true, markers = "extra == \"cli\" or extra == \"test-tools\" or extra == \"all\""}
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+pyyaml = {version = ">=6.0.1,<7", optional = true, markers = "extra == \"cli\" or extra == \"test-tools\" or extra == \"all\""}
 
 [package.extras]
-all = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<8.0.0)", "jsonschema (>=4.3.0,<4.24.0)", "packaging (==26)", "pytest (>=8.2,<10)", "pyyaml (>=6.0.1,<9)", "semver (>=2.9.1,<3.0.0)"]
-cli = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<8.0.0)", "jsonschema (>=4.3.0,<4.24.0)", "packaging (==26)", "pytest (>=8.2,<10)", "pyyaml (>=6.0.1,<9)", "semver (>=2.9.1,<3.0.0)"]
-test-tools = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<8.0.0)", "jsonschema (>=4.3.0,<4.24.0)", "packaging (==26)", "pytest (>=8.2,<10)", "pyyaml (>=6.0.1,<9)", "semver (>=2.9.1,<3.0.0)"]
+all = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<9)", "packaging (>=22.0,<27)", "pytest (>=7.0,<10)", "pyyaml (>=6.0.1,<7)"]
+cli = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<9)", "packaging (>=22.0,<27)", "pytest (>=7.0,<10)", "pyyaml (>=6.0.1,<7)"]
+test-tools = ["click (>=8.1.0,<8.4.0)", "coverage (>=6.4.4,<9)", "packaging (>=22.0,<27)", "pytest (>=7.0,<10)", "pyyaml (>=6.0.1,<7)"]
 
 [[package]]
 name = "open-aea-cli-ipfs"
-version = "2.1.0"
+version = "2.2.1"
 description = "CLI extension for open AEA framework wrapping IPFS functionality."
 optional = false
-python-versions = "*"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_cli_ipfs-2.1.0-py3-none-any.whl", hash = "sha256:dabebcf724f42990c4440ae0d45ef9e393a140c052cfd420298234a56b35e128"},
-    {file = "open_aea_cli_ipfs-2.1.0.tar.gz", hash = "sha256:b9a2c4d851a6b8ea7fd0d3b0b29623a3336712392dccd615da0acc710dc472d2"},
+    {file = "open_aea_cli_ipfs-2.2.1-py3-none-any.whl", hash = "sha256:e81dba96c6661c073ae634e91a2f588d710b58879c3b398f6914d0cf73de9ed1"},
+    {file = "open_aea_cli_ipfs-2.2.1.tar.gz", hash = "sha256:3bfa4da06c5ddb0d1622be624c6fa60a00b1e691ca8ed5a0f602581883c20f13"},
 ]
 
 [package.dependencies]
-ipfshttpclient = ">=0.8.0a2"
+click = ">=8.1.0,<8.4.0"
 open-aea = ">=2.0.0,<3.0.0"
 
-[[package]]
-name = "open-aea-flashbots"
-version = "2.1.0"
-description = ""
-optional = false
-python-versions = "<4.0,>=3.10"
-groups = ["main"]
-files = [
-    {file = "open_aea_flashbots-2.1.0-py3-none-any.whl", hash = "sha256:4ce58aa721fb58ca1da97e5f135218c2451922847f1b707412357cf2ff7eefb2"},
-    {file = "open_aea_flashbots-2.1.0.tar.gz", hash = "sha256:65a4e39615d59f96c8d6254cc6f7f9568f3e0253c66da8ff9042b1f51c80e494"},
-]
-
-[package.dependencies]
-web3 = ">=7,<8"
+[package.extras]
+test-tools = ["pytest (>=7.0,<10)"]
 
 [[package]]
 name = "open-aea-ledger-cosmos"
-version = "2.1.0"
+version = "2.2.1"
 description = "Python package wrapping the public and private key cryptography and ledger api of Cosmos."
 optional = false
-python-versions = "*"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_cosmos-2.1.0-py3-none-any.whl", hash = "sha256:0b93b19691e6cfc5a92dd2447e4a2dbc0c5f065ac4d04d961d927be97a7a0178"},
-    {file = "open_aea_ledger_cosmos-2.1.0.tar.gz", hash = "sha256:59d36720d3d34c3e440a14a1048cbd62782960abbb29742694a409bb1defad71"},
+    {file = "open_aea_ledger_cosmos-2.2.1-py3-none-any.whl", hash = "sha256:fef0a9bdf65e50884e674f9441147aa56b435b84bc15dedb70b60111d2f1410d"},
+    {file = "open_aea_ledger_cosmos-2.2.1.tar.gz", hash = "sha256:5afe4d6b22e4f187e277aceb6512b35a3cb7fc5d0c59333a6361af26b6cb878f"},
 ]
 
 [package.dependencies]
 bech32 = ">=1.2.0,<2"
 cosmpy = ">=0.11.0,<0.12"
-ecdsa = ">=0.15,<0.17.0"
+ecdsa = ">=0.19.2,<0.20"
 open-aea = ">=2.0.0,<3.0.0"
 pycryptodome = ">=3.10.1,<4.0.0"
+requests = ">=2.32.5,<3"
 
 [[package]]
 name = "open-aea-ledger-ethereum"
-version = "2.1.0"
+version = "2.2.1"
 description = "Python package wrapping the public and private key cryptography and ledger api of Ethereum."
 optional = false
-python-versions = "*"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_ethereum-2.1.0-py3-none-any.whl", hash = "sha256:04670f26a86670052af9e4e2e675631d2ac8e40b5cae5143d9808ca36e96172d"},
-    {file = "open_aea_ledger_ethereum-2.1.0.tar.gz", hash = "sha256:56f6ca96036e7afa5ae69958455ad23087d712fbc04a0c05c23704e7449a4bd3"},
+    {file = "open_aea_ledger_ethereum-2.2.1-py3-none-any.whl", hash = "sha256:5ee4eda46bd1f3643815db4ec4e559d9dd16f6d123669aed0d6823148e895260"},
+    {file = "open_aea_ledger_ethereum-2.2.1.tar.gz", hash = "sha256:5d34cfb08472d819d46fd1e591c82b8a108260603078eb76f272de15a59237fa"},
 ]
 
 [package.dependencies]
 eth-account = ">=0.13.0,<0.14.0"
-ipfshttpclient = "0.8.0a2"
 open-aea = ">=2.0.0,<3.0.0"
+requests = ">=2.32.5,<3"
 web3 = ">=7.0.0,<8"
 
-[[package]]
-name = "open-aea-ledger-ethereum-flashbots"
-version = "2.1.0"
-description = "Python package extending the default open-aea ethereum ledger plugin to add support for flashbots."
-optional = false
-python-versions = "<4.0,>=3.10"
-groups = ["main"]
-files = [
-    {file = "open_aea_ledger_ethereum_flashbots-2.1.0-py3-none-any.whl", hash = "sha256:800acd6c5a22db7052d53576f719925de89626c147cf1a68982b643a2a11d45e"},
-    {file = "open_aea_ledger_ethereum_flashbots-2.1.0.tar.gz", hash = "sha256:20b7cce44c91636aec32fe311dc466ec79ab01644f9e4b8b4036c12300d43b69"},
-]
-
-[package.dependencies]
-open-aea-flashbots = ">=2.1.0,<2.2.0"
-open-aea-ledger-ethereum = ">=2.1.0,<2.2.0"
+[package.extras]
+test-tools = ["docker (==7.1.0)", "pytest (>=7.0,<10)"]
 
 [[package]]
 name = "open-autonomy"
-version = "0.21.13"
-description = "A framework for the creation of autonomous agent services."
+version = "0.21.19"
+description = "Open Autonomy Framework"
 optional = false
-python-versions = ">=3.10"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_autonomy-0.21.13-py3-none-any.whl", hash = "sha256:bbb495faeb2a88f47a6f31806af41ae173e19ad82633fcb7e87111ae9260c7fa"},
-    {file = "open_autonomy-0.21.13.tar.gz", hash = "sha256:eedc9bf38f8b07368a4259088afd3064ed459b16360c34b2d55f5b94f7ada5c9"},
+    {file = "open_autonomy-0.21.19-py3-none-any.whl", hash = "sha256:aaf96296474cac52758c673721c866e8a952eba137a176f2f2098ad712343daa"},
+    {file = "open_autonomy-0.21.19.tar.gz", hash = "sha256:2c2df7e6d3858ff1efd72b397962ce6bd47bab8ccfdb6612f4c93b622987b323"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.5,<4.0.0"
-click = ">=8.1.0,<9"
-coverage = ">=6.4.4,<8.0.0"
-docker = "7.1.0"
-Flask = ">=3.1.0,<4.0.0"
-gql = "3.5.0"
-hexbytes = "*"
-jsonschema = ">=4.3.0,<4.24.0"
-multiaddr = "0.0.9"
-open-aea = {version = "2.1.0", extras = ["all"]}
-open-aea-cli-ipfs = "2.1.0"
-protobuf = ">=5,<6"
-pytest = "8.4.2"
-python-dotenv = ">=0.14.5,<0.22.0"
-requests = ">=2.28.1,<2.33.0"
-requests-toolbelt = "1.0.0"
-texttable = "1.6.7"
-typing_extensions = ">=3.10.0.2,<=4.15.0"
-watchdog = ">=2.1.6"
-werkzeug = ">=3.1.0,<4.0.0"
+asn1crypto = ">=1.4.0,<1.5.0"
+certifi = "*"
+docker = {version = "7.1.0", optional = true, markers = "extra == \"docker\""}
+ecdsa = "*"
+grpcio = "1.78.0"
+multidict = "*"
+open-aea = {version = "2.2.1", extras = ["all"]}
+open-aea-cli-ipfs = {version = "2.2.1", optional = true, markers = "extra == \"cli\" or extra == \"all\""}
+open-aea-ledger-cosmos = "2.2.1"
+protobuf = "*"
+py-ecc = ">=8,<10"
+pytest-asyncio = "*"
+requests = "*"
+web3 = "*"
 
 [package.extras]
-all = ["click (>=8.1.0,<9)", "coverage (>=6.4.4,<8.0.0)", "open-aea-cli-ipfs (==2.1.0)", "pytest (>=8.0.0,<8.5.0)", "python-dotenv (>=0.14.5,<0.22.0)", "texttable (==1.6.7)"]
-cli = ["click (>=8.1.0,<9)", "coverage (>=6.4.4,<8.0.0)", "open-aea-cli-ipfs (==2.1.0)", "pytest (>=8.0.0,<8.5.0)", "python-dotenv (>=0.14.5,<0.22.0)", "texttable (==1.6.7)"]
+all = ["open-aea-cli-ipfs (==2.2.1)", "open-aea-ledger-ethereum (==2.2.1)"]
+chain = ["open-aea-ledger-ethereum (==2.2.1)"]
+cli = ["open-aea-cli-ipfs (==2.2.1)"]
+docker = ["docker (==7.1.0)"]
+hwi = ["open-aea-ledger-ethereum-hwi (==2.2.1)"]
 
 [[package]]
 name = "orderly-set"
@@ -2999,42 +2888,25 @@ files = [
 test = ["enum34 ; python_version <= \"3.4\"", "ipaddress ; python_version < \"3.0\"", "mock ; python_version < \"3.0\"", "pywin32 ; sys_platform == \"win32\"", "wmi ; sys_platform == \"win32\""]
 
 [[package]]
-name = "py-multibase"
-version = "2.0.0"
-description = "Multibase implementation for Python"
+name = "py-ecc"
+version = "8.0.0"
+description = "py-ecc: Elliptic curve crypto in python including secp256k1, alt_bn128, and bls12_381"
 optional = false
-python-versions = "<4.0,>=3.10"
+python-versions = "<4,>=3.8"
 groups = ["main"]
 files = [
-    {file = "py_multibase-2.0.0-py3-none-any.whl", hash = "sha256:b29ce489b556134e73998a11712c406b70950812955df64084754e0774e40900"},
-    {file = "py_multibase-2.0.0.tar.gz", hash = "sha256:58c1a264195fa1ae29ea707c6fc8196446f4bdb92e0f9a0f131e0f280b238839"},
+    {file = "py_ecc-8.0.0-py3-none-any.whl", hash = "sha256:c0b2dfc4bde67a55122a392591a10e851a986d5128f680628c80b405f7663e13"},
+    {file = "py_ecc-8.0.0.tar.gz", hash = "sha256:56aca19e5dc37294f60c1cc76666c03c2276e7666412b9a559fa0145d099933d"},
 ]
 
 [package.dependencies]
-morphys = ">=1.0,<2.0"
-python-baseconv = ">=1.2.0,<2.0"
-six = ">=1.10.0,<2.0"
+eth-typing = ">=3.0.0"
+eth-utils = ">=2.0.0"
 
 [package.extras]
-dev = ["Sphinx (>=5.0.0)", "build (>=0.9.0)", "bump-my-version (>=1.2.0)", "mypy", "pre-commit", "pytest", "pytest-runner", "ruff", "towncrier (>=24,<25)", "tox (>=4.10.0)", "twine", "watchdog (>=3.0.0)", "wheel (>=0.31.0)"]
-
-[[package]]
-name = "py-multicodec"
-version = "1.0.0"
-description = "Multicodec implementation in Python"
-optional = false
-python-versions = "<4.0,>=3.10"
-groups = ["main"]
-files = [
-    {file = "py_multicodec-1.0.0-py3-none-any.whl", hash = "sha256:ae2e687bac8fdf54e3f5b3feded36b61a304d5e3c3af9438f7481f543ec15b8d"},
-    {file = "py_multicodec-1.0.0.tar.gz", hash = "sha256:78e4e3e47b6288cf635c3ca987152e6cb5510bdcdab307e7690c76ec3d5bbfeb"},
-]
-
-[package.dependencies]
-varint = ">=1.0.2,<2.0.0"
-
-[package.extras]
-dev = ["Sphinx (>=5.0.0)", "build (>=0.9.0)", "bump-my-version (>=1.2.0)", "mypy", "pre-commit", "pytest", "pytest-runner", "ruff", "towncrier (>=24,<25)", "tox (>=4.10.0)", "twine", "watchdog (>=3.0.0)", "wheel (>=0.31.0)"]
+dev = ["build (>=0.9.0)", "bump_my_version (>=0.19.0)", "ipython", "mypy (==1.10.0)", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)"]
+test = ["pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "pycparser"
@@ -3323,22 +3195,6 @@ packaging = ">=22.0"
 setuptools = ">=42.0.0"
 
 [[package]]
-name = "pymultihash"
-version = "0.8.2"
-description = "Python implementation of the multihash specification"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pymultihash-0.8.2-py3-none-any.whl", hash = "sha256:f7fa840b24bd6acbd6b073fcd330f10e15619387297babf1dd13ca4dae6e8209"},
-    {file = "pymultihash-0.8.2.tar.gz", hash = "sha256:49c75a1ae9ecc6d22d259064d4597b3685da3f0258f4ded632e03a3a79af215b"},
-]
-
-[package.extras]
-blake2 = ["pyblake2"]
-sha3 = ["pysha3"]
-
-[[package]]
 name = "pynacl"
 version = "1.6.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
@@ -3447,7 +3303,7 @@ version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.10"
-groups = ["development"]
+groups = ["main", "development"]
 files = [
     {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
     {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
@@ -3524,17 +3380,6 @@ setproctitle = ["setproctitle"]
 testing = ["filelock"]
 
 [[package]]
-name = "python-baseconv"
-version = "1.2.2"
-description = "Convert numbers from base 10 integers to base X strings and back again."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "python-baseconv-1.2.2.tar.gz", hash = "sha256:0539f8bd0464013b05ad62e0a1673f0ac9086c76b43ebf9f833053527cd9931b"},
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3568,21 +3413,6 @@ platformdirs = ">=4.3.6,<5"
 [package.extras]
 docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
-
-[[package]]
-name = "python-dotenv"
-version = "0.21.1"
-description = "Read key-value pairs from a .env file and set them as environment variables"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49"},
-    {file = "python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a"},
-]
-
-[package.extras]
-cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pyunormalize"
@@ -3905,21 +3735,6 @@ requests = ">=2.22,<3"
 fixture = ["fixtures"]
 
 [[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-description = "A utility belt for advanced users of python-requests"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["main"]
-files = [
-    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
-    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
-]
-
-[package.dependencies]
-requests = ">=2.0.1,<3.0.0"
-
-[[package]]
 name = "rlp"
 version = "4.1.0"
 description = "rlp: A package for Recursive Length Prefix encoding and decoding"
@@ -4066,18 +3881,6 @@ files = [
 ]
 
 [[package]]
-name = "semver"
-version = "2.13.0"
-description = "Python helper for Semantic Versioning (http://semver.org/)"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["main"]
-files = [
-    {file = "semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4"},
-    {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
-]
-
-[[package]]
 name = "setuptools"
 version = "82.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -4168,18 +3971,6 @@ files = [
 tests = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "texttable"
-version = "1.6.7"
-description = "module to create simple ASCII tables"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "texttable-1.6.7-py2.py3-none-any.whl", hash = "sha256:b7b68139aa8a6339d2c320ca8b1dc42d13a7831a346b446cb9eb385f0c76310c"},
-    {file = "texttable-1.6.7.tar.gz", hash = "sha256:290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.0"
 description = "A lil' TOML parser"
@@ -4239,14 +4030,14 @@ markers = {main = "python_version == \"3.10\"", development = "python_full_versi
 
 [[package]]
 name = "tomte"
-version = "0.6.1"
+version = "0.6.5"
 description = "A library that wraps many useful tools (linters, analysers, etc) to keep Python code clean, secure, well-documented and optimised."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["development"]
 files = [
-    {file = "tomte-0.6.1-py3-none-any.whl", hash = "sha256:3fdd83a7f38bc3a43aa5ce24a2ce84c9a34904cf5887bff06c9cb781024ac59f"},
-    {file = "tomte-0.6.1.tar.gz", hash = "sha256:1e039fd94b1fdd0202c7a4dc01e9324e3786fb2ff18ac5bb6cce142edf9f779e"},
+    {file = "tomte-0.6.5-py3-none-any.whl", hash = "sha256:7a89379b640fced037d6ea367d6ae7167f50b1088d7ed9cb6bec3d51341ce45c"},
+    {file = "tomte-0.6.5.tar.gz", hash = "sha256:f19c1b57d74394b91cfe001eac4445c3163d956b16a599f9b6de20873de0e777"},
 ]
 
 [package.dependencies]
@@ -4497,49 +4288,6 @@ objprint = ">=0.3.0"
 
 [package.extras]
 full = ["orjson"]
-
-[[package]]
-name = "watchdog"
-version = "6.0.0"
-description = "Filesystem events monitoring"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
-    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
-    {file = "watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3"},
-    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
-    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
-    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
-    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
-    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
-    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
-    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
-    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
-    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
-    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8"},
-    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a"},
-    {file = "watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c"},
-    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881"},
-    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11"},
-    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa"},
-    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
-    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
-    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
-    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
-    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
-    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
-]
-
-[package.extras]
-watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "web3"
@@ -5002,4 +4750,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.15,>=3.10"
-content-hash = "f865505f246d7b6d0c7c2c177b64bedd902d666ea04bee00b101123bf8b19ea1"
+content-hash = "2efc72f3b33fdd7031a7b510cb8cf4ede6de4b083b576dc04fdb21be031d5e2a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,10 @@ operate = "operate.cli:main"
 
 [tool.poetry.dependencies]
 python = "<3.15,>=3.10"
-open-autonomy = {version = "^0.21.13", extras = ["cli"]}
-open-aea-ledger-cosmos = "^2.1.0"
-open-aea-ledger-ethereum = "^2.1.0"
-open-aea-ledger-ethereum-flashbots = "^2.1.0"
-open-aea-cli-ipfs = "^2.1.0"
+open-autonomy = {version = "^0.21.19", extras = ["cli", "docker"]}
+open-aea-ledger-cosmos = "==2.2.1"
+open-aea-ledger-ethereum = "==2.2.1"
+open-aea-cli-ipfs = "==2.2.1"
 clea = "==0.1.0rc4"
 cytoolz = "<1.2.0,>=1.0.0"
 fastapi = "0.110.3"
@@ -36,9 +35,17 @@ argon2-cffi = "==23.1.0"
 requests-mock = "^1.12.1"
 multiaddr = "==0.0.9"
 cryptography = "^46.0.3"
+# Direct deps for packages no longer pulled in transitively after the
+# open-autonomy 0.21.19 / open-aea 2.2.1 dependency-footprint trim.
+aiohttp = "^3.10"
+flask = "^3.0"
+werkzeug = "^3.0"
+hexbytes = "^1.2"
+typing_extensions = "^4.12"
+requests = "^2.32"
 
 [tool.poetry.group.development.dependencies]
-tomte = {version = "0.6.1", extras = ["cli"]}
+tomte = {version = "0.6.5", extras = ["cli"]}
 build = "1.2.2.post1"
 yappi = "^1.6.10"
 viztracer = "^1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ operate = "operate.cli:main"
 [tool.poetry.dependencies]
 python = "<3.15,>=3.10"
 open-autonomy = {version = "^0.21.19", extras = ["cli", "docker"]}
-open-aea-ledger-cosmos = "==2.2.1"
-open-aea-ledger-ethereum = "==2.2.1"
-open-aea-cli-ipfs = "==2.2.1"
+open-aea-ledger-cosmos = "^2.2.1"
+open-aea-ledger-ethereum = "^2.2.1"
+open-aea-cli-ipfs = "^2.2.1"
 clea = "==0.1.0rc4"
 cytoolz = "<1.2.0,>=1.0.0"
 fastapi = "0.110.3"

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -31,7 +31,6 @@ from operate.services.protocol import (
     MintManager,
     StakingManager,
     StakingState,
-    _normalize_multisend_tx_data,
 )
 
 # ---------------------------------------------------------------------------
@@ -98,20 +97,14 @@ class TestGnosisSafeTransaction:
         assert tx._txs == []
 
     def test_add_appends_tx_and_returns_self(self) -> None:
-        """Test add() appends a normalised tx dict and returns self for chaining."""
+        """Test add() appends the tx dict as-is and returns self for chaining."""
         safe_tx = self._make_safe_tx()
-        tx_dict = {"to": "0xRecipient", "value": 0, "data": "0xabcd"}
+        tx_dict = {"to": "0xRecipient", "value": 0, "data": b"\xab\xcd"}
 
         result = safe_tx.add(tx_dict)
 
         assert result is safe_tx
-        assert safe_tx._txs == [{"to": "0xRecipient", "value": 0, "data": b"\xab\xcd"}]
-
-    def test_add_defaults_missing_data_to_empty_bytes(self) -> None:
-        """Test add() injects ``data=b''`` when the input tx omits the field."""
-        safe_tx = self._make_safe_tx()
-        safe_tx.add({"to": "0xRecipient", "value": 0})
-        assert safe_tx._txs == [{"to": "0xRecipient", "value": 0, "data": b""}]
+        assert safe_tx._txs == [tx_dict]
 
     def test_add_multiple_txs(self) -> None:
         """Test add() can be called multiple times to accumulate transactions."""
@@ -168,37 +161,6 @@ class TestGnosisSafeTransaction:
         mock_contracts.gnosis_safe.get_raw_safe_transaction_hash.assert_called_once()
         mock_contracts.gnosis_safe.get_raw_safe_transaction.assert_called_once()
         assert isinstance(result, dict)
-
-
-class TestNormalizeMultisendTxData:
-    """Tests for _normalize_multisend_tx_data."""
-
-    def test_bytes_passthrough(self) -> None:
-        """Test bytes input is returned unchanged (as bytes)."""
-        assert _normalize_multisend_tx_data(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
-
-    def test_bytearray_coerced_to_bytes(self) -> None:
-        """Test bytearray input is coerced to bytes."""
-        result = _normalize_multisend_tx_data(bytearray(b"\xde\xad"))
-        assert result == b"\xde\xad"
-        assert isinstance(result, bytes)
-
-    def test_hex_string_with_0x_prefix(self) -> None:
-        """Test hex string with 0x prefix is decoded to bytes."""
-        assert _normalize_multisend_tx_data("0xdeadbeef") == b"\xde\xad\xbe\xef"
-
-    def test_hex_string_with_0X_prefix(self) -> None:
-        """Test hex string with uppercase 0X prefix is decoded to bytes."""
-        assert _normalize_multisend_tx_data("0Xdeadbeef") == b"\xde\xad\xbe\xef"
-
-    def test_hex_string_without_prefix(self) -> None:
-        """Test bare hex string is decoded to bytes."""
-        assert _normalize_multisend_tx_data("deadbeef") == b"\xde\xad\xbe\xef"
-
-    def test_unsupported_type_raises(self) -> None:
-        """Test non-str/bytes input raises TypeError."""
-        with pytest.raises(TypeError, match="Unsupported multisend tx data type"):
-            _normalize_multisend_tx_data(12345)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -31,6 +31,7 @@ from operate.services.protocol import (
     MintManager,
     StakingManager,
     StakingState,
+    _normalize_multisend_tx_data,
 )
 
 # ---------------------------------------------------------------------------
@@ -97,20 +98,26 @@ class TestGnosisSafeTransaction:
         assert tx._txs == []
 
     def test_add_appends_tx_and_returns_self(self) -> None:
-        """Test add() appends the tx dict to _txs and returns self for chaining."""
+        """Test add() appends a normalised tx dict and returns self for chaining."""
         safe_tx = self._make_safe_tx()
-        tx_dict = {"to": "0xRecipient", "value": 0}
+        tx_dict = {"to": "0xRecipient", "value": 0, "data": "0xabcd"}
 
         result = safe_tx.add(tx_dict)
 
         assert result is safe_tx
-        assert safe_tx._txs == [tx_dict]
+        assert safe_tx._txs == [{"to": "0xRecipient", "value": 0, "data": b"\xab\xcd"}]
+
+    def test_add_defaults_missing_data_to_empty_bytes(self) -> None:
+        """Test add() injects ``data=b''`` when the input tx omits the field."""
+        safe_tx = self._make_safe_tx()
+        safe_tx.add({"to": "0xRecipient", "value": 0})
+        assert safe_tx._txs == [{"to": "0xRecipient", "value": 0, "data": b""}]
 
     def test_add_multiple_txs(self) -> None:
         """Test add() can be called multiple times to accumulate transactions."""
         safe_tx = self._make_safe_tx()
-        tx1 = {"to": "0xA", "value": 0}
-        tx2 = {"to": "0xB", "value": 1}
+        tx1 = {"to": "0xA", "value": 0, "data": b""}
+        tx2 = {"to": "0xB", "value": 1, "data": b""}
 
         safe_tx.add(tx1).add(tx2)
 
@@ -161,6 +168,37 @@ class TestGnosisSafeTransaction:
         mock_contracts.gnosis_safe.get_raw_safe_transaction_hash.assert_called_once()
         mock_contracts.gnosis_safe.get_raw_safe_transaction.assert_called_once()
         assert isinstance(result, dict)
+
+
+class TestNormalizeMultisendTxData:
+    """Tests for _normalize_multisend_tx_data."""
+
+    def test_bytes_passthrough(self) -> None:
+        """Test bytes input is returned unchanged (as bytes)."""
+        assert _normalize_multisend_tx_data(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
+
+    def test_bytearray_coerced_to_bytes(self) -> None:
+        """Test bytearray input is coerced to bytes."""
+        result = _normalize_multisend_tx_data(bytearray(b"\xde\xad"))
+        assert result == b"\xde\xad"
+        assert isinstance(result, bytes)
+
+    def test_hex_string_with_0x_prefix(self) -> None:
+        """Test hex string with 0x prefix is decoded to bytes."""
+        assert _normalize_multisend_tx_data("0xdeadbeef") == b"\xde\xad\xbe\xef"
+
+    def test_hex_string_with_0X_prefix(self) -> None:
+        """Test hex string with uppercase 0X prefix is decoded to bytes."""
+        assert _normalize_multisend_tx_data("0Xdeadbeef") == b"\xde\xad\xbe\xef"
+
+    def test_hex_string_without_prefix(self) -> None:
+        """Test bare hex string is decoded to bytes."""
+        assert _normalize_multisend_tx_data("deadbeef") == b"\xde\xad\xbe\xef"
+
+    def test_unsupported_type_raises(self) -> None:
+        """Test non-str/bytes input raises TypeError."""
+        with pytest.raises(TypeError, match="Unsupported multisend tx data type"):
+            _normalize_multisend_tx_data(12345)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_protocol_unit2.py
+++ b/tests/test_protocol_unit2.py
@@ -1500,6 +1500,8 @@ class TestEthSafeTxBuilderStakingDataMethods:
 
         assert result["to"] == _CONTRACTS["service_registry"]
         assert result["from"] == _SAFE_ADDRESS
+        assert isinstance(result["data"], bytes)
+        assert result["data"] == bytes.fromhex(_ENCODED[2:])
 
     def test_get_staking_data_delegates_to_staking_manager(self) -> None:
         """get_staking_data calls StakingManager and returns dict."""
@@ -1515,6 +1517,8 @@ class TestEthSafeTxBuilderStakingDataMethods:
             )
 
         assert result["to"] == _STAKING_CONTRACT
+        assert isinstance(result["data"], bytes)
+        assert result["data"] == bytes.fromhex(_ENCODED[2:])
 
     def test_get_unstaking_data_normal_path(self) -> None:
         """get_unstaking_data calls get_unstake_tx_data when force=False."""
@@ -1532,6 +1536,8 @@ class TestEthSafeTxBuilderStakingDataMethods:
         mock_sm.get_unstake_tx_data.assert_called_once()
         mock_sm.get_forced_unstake_tx_data.assert_not_called()
         assert result["to"] == _STAKING_CONTRACT
+        assert isinstance(result["data"], bytes)
+        assert result["data"] == bytes.fromhex(_ENCODED[2:])
 
     def test_get_unstaking_data_force_path(self) -> None:
         """get_unstaking_data calls get_forced_unstake_tx_data when force=True."""
@@ -1549,6 +1555,8 @@ class TestEthSafeTxBuilderStakingDataMethods:
         mock_sm.get_forced_unstake_tx_data.assert_called_once()
         mock_sm.get_unstake_tx_data.assert_not_called()
         assert result["to"] == _STAKING_CONTRACT
+        assert isinstance(result["data"], bytes)
+        assert result["data"] == bytes.fromhex(_ENCODED[2:])
 
     def test_get_claiming_data_delegates_to_staking_manager(self) -> None:
         """get_claiming_data calls get_claim_tx_data and returns dict."""
@@ -1565,6 +1573,8 @@ class TestEthSafeTxBuilderStakingDataMethods:
 
         mock_sm.get_claim_tx_data.assert_called_once()
         assert result["to"] == _STAKING_CONTRACT
+        assert isinstance(result["data"], bytes)
+        assert result["data"] == bytes.fromhex(_ENCODED[2:])
 
     def test_staking_slots_available_delegates(self) -> None:
         """staking_slots_available patches and delegates to StakingManager."""

--- a/tox.ini
+++ b/tox.ini
@@ -123,18 +123,24 @@ commands =
 [testenv:unit-tests]
 deps =
     tomte[tests]==0.6.5
+    httpx
+    pytest-recording
 commands =
     pytest -m "not integration" -v --durations=100 {posargs:tests/}
 
 [testenv:unit-tests-coverage]
 deps =
     tomte[tests]==0.6.5
+    httpx
+    pytest-recording
 commands =
     pytest -m "not integration" -v --durations=100 --cov=operate --cov-report=xml --cov-report=term-missing --cov-fail-under=100 {posargs:tests/}
 
 [testenv:integration-tests]
 deps =
     tomte[tests]==0.6.5
+    httpx
+    pytest-recording
     pytest-xdist==3.8.0
 commands =
     pytest -m "integration" -n {env:PYTEST_XDIST_WORKERS:auto} --dist {env:PYTEST_XDIST_DIST:worksteal} -v --durations=100 {posargs:tests/}

--- a/tox.ini
+++ b/tox.ini
@@ -67,9 +67,6 @@ commands =
 [testenv:pylint]
 whitelist_externals = /bin/sh
 skipsdist = True
-allowlist_externals = poetry
-commands_pre = 
-    poetry install
 deps =
     tomte[pylint]==0.6.5
 commands =
@@ -124,30 +121,18 @@ commands =
     liccheck -s tox.ini -r {envtmpdir}/requirements.txt -l PARANOID
 
 [testenv:unit-tests]
-allowlist_externals = *poetry*
-commands_pre =
-    {env:POETRY_EXE:poetry} install
-skip_install = True
 deps =
     tomte[tests]==0.6.5
 commands =
     pytest -m "not integration" -v --durations=100 {posargs:tests/}
 
 [testenv:unit-tests-coverage]
-allowlist_externals = *poetry*
-commands_pre =
-    {env:POETRY_EXE:poetry} install
-skip_install = True
 deps =
     tomte[tests]==0.6.5
 commands =
     pytest -m "not integration" -v --durations=100 --cov=operate --cov-report=xml --cov-report=term-missing --cov-fail-under=100 {posargs:tests/}
 
 [testenv:integration-tests]
-allowlist_externals = *poetry*
-commands_pre =
-    {env:POETRY_EXE:poetry} install
-skip_install = True
 deps =
     tomte[tests]==0.6.5
     pytest-xdist==3.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv = *
 skipsdist = True
 skip_install = True
 deps =
-    tomte[bandit]==0.6.1
+    tomte[bandit]==0.6.5
 commands =
     bandit -r operate -x */tests/*
     bandit -s B101 -r tests
@@ -19,7 +19,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.6.1
+    tomte[black]==0.6.5
 commands =
     black operate tests --exclude operate/data
 
@@ -27,7 +27,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.6.1
+    tomte[black]==0.6.5
 commands =
     black --check operate tests --exclude operate/data
 
@@ -35,7 +35,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.6.1
+    tomte[isort]==0.6.5
 commands =
     isort operate/ tests/ --profile black --skip operate/data
 
@@ -43,7 +43,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.6.1
+    tomte[isort]==0.6.5
 commands =
     isort --check-only --profile black --gitignore operate/ tests/ --skip operate/data
 
@@ -51,7 +51,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[flake8]==0.6.1
+    tomte[flake8]==0.6.5
 commands =
     flake8 operate tests
 
@@ -59,7 +59,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[mypy]==0.6.1
+    tomte[mypy]==0.6.5
     types-cryptography  # TODO backport to tomte repository
 commands =
     mypy operate/ tests/ --disallow-untyped-defs --config-file tox.ini
@@ -71,7 +71,7 @@ allowlist_externals = poetry
 commands_pre = 
     poetry install
 deps =
-    tomte[pylint]==0.6.1
+    tomte[pylint]==0.6.5
 commands =
     pylint operate -j 0 --rcfile=.pylintrc
 
@@ -79,7 +79,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[safety]==0.6.1
+    tomte[safety]==0.6.5
     typer<0.17.0  # remove after this is fixed https://github.com/pyupio/safety/issues/784
 commands =
     safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599 -i 70612
@@ -88,7 +88,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[vulture]==0.6.1
+    tomte[vulture]==0.6.5
 commands =
     vulture operate/services scripts/whitelist.py
 
@@ -96,7 +96,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[darglint]==0.6.1
+    tomte[darglint]==0.6.5
 commands =
     darglint operate tests
 
@@ -118,7 +118,7 @@ commands =
 [testenv:liccheck]
 skipsdist = True
 usedevelop = True
-deps = tomte[liccheck,cli]==0.6.1
+deps = tomte[liccheck,cli]==0.6.5
 commands =
     tomte freeze-dependencies --output-path {envtmpdir}/requirements.txt
     liccheck -s tox.ini -r {envtmpdir}/requirements.txt -l PARANOID
@@ -129,7 +129,7 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.6.5
 commands =
     pytest -m "not integration" -v --durations=100 {posargs:tests/}
 
@@ -139,7 +139,7 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.6.5
 commands =
     pytest -m "not integration" -v --durations=100 --cov=operate --cov-report=xml --cov-report=term-missing --cov-fail-under=100 {posargs:tests/}
 
@@ -149,14 +149,14 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.6.5
     pytest-xdist==3.8.0
 commands =
     pytest -m "integration" -n {env:PYTEST_XDIST_WORKERS:auto} --dist {env:PYTEST_XDIST_DIST:worksteal} -v --durations=100 {posargs:tests/}
 
 [testenv:all-tests]
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.6.5
     httpx
     pytest-recording
 commands =


### PR DESCRIPTION
## Summary

Bumps the upstream framework dep stack to the latest tagged releases:

| Package | Before | After |
|---|---|---|
| open-autonomy | 0.21.13 (extras `[cli]`) | **0.21.19** (extras `[cli, docker]`) |
| open-aea (core) | 2.1.0 | **2.2.1** |
| open-aea-ledger-ethereum | 2.1.0 | **2.2.1** (`^2.2.1`) |
| open-aea-ledger-cosmos | 2.1.0 | **2.2.1** (`^2.2.1`) |
| open-aea-cli-ipfs | 2.1.0 | **2.2.1** (`^2.2.1`) |
| open-aea-ledger-ethereum-flashbots | 2.1.0 | **removed** |
| tomte | 0.6.1 | **0.6.5** |

### Code changes beyond the version pins

- **Drops `open-aea-ledger-ethereum-flashbots`** (plugin removed upstream in open-aea 2.2.1):
  - Removed from `pyproject.toml`
  - Removed PyInstaller bundle hint in `operate/pearl.py`
  - Removed from agent-venv pip install in `operate/services/deployment_runner.py`
  - **Kept** the skill-level `use_flashbots` parameter in `operate/utils/gnosis.py` — payload wire format is intentionally preserved per the OA upgrading guide.

- **Adds explicit pins** for packages no longer pulled in transitively after the OA 0.21.19 / OAEA 2.2.0 dependency-footprint trim, but used directly by `operate/`:
  - `aiohttp` (used by `operate/services/health_checker.py`)
  - `flask`, `werkzeug` (used by `operate/services/utils/tendermint.py`)
  - `hexbytes` (used by `operate/services/protocol.py`)
  - `typing_extensions` (used by `operate/operate_types.py`, `operate/cli.py`)
  - `requests` (used in 9 files; previously transitive via OAEA core, now declared explicitly)

- **`open-autonomy` extras flipped** from `[cli]` to `[cli, docker]` — `docker` is now an optional extra in OA 0.21.19, and `operate/services/service.py` imports `docker` directly.

- **`tomte` bumped** from `0.6.1` to `0.6.5` across `pyproject.toml`, `tox.ini` (16 sites), and `.github/workflows/common_checks.yml` (4 sites). Required for OAEA 2.2.x compatibility.

### Why `^2.2.1` for the open-aea plugins

Caret pin (per @OjusWiZard) so the constraint doesn't propagate as a hard pin to downstream consumers (`mech-client`, `mech-tools-dev`). The lock currently resolves to 2.2.1 anyway because `open-autonomy 0.21.19` strict-pins `open-aea==2.2.1` transitively, so we get the version stability we want without locking out future OA versions.

### Multisend bytes coercion (OA 0.21.19 breaking change)

OA 0.21.19 inlined the multisend encoder and dropped its `HexBytes()` wrapper, so `multisend.encode_data` now requires strict `bytes` for `tx["data"]`. Pre-0.21.19, hex-string slices (`encode_abi(...)[2:]`) worked silently via the HexBytes coercion. After review feedback (thanks @jmoreira-valory) the coercion is applied **inline at every call site** in `operate/services/protocol.py` (~19 sites), not via a helper:

- `get_mint_tx_data`, `get_erc20_approval_data`, `get_activate_data`, `get_register_instances_data`, `get_deploy_data_from_safe`
- `get_safe_b_eth_transfer_messages`, `get_safe_b_erc20_transfer_messages` (approve + exec for both)
- `get_terminate_service_data`, `get_unbond_service_data`
- `get_staking_approval_data`, `get_staking_data`, `get_unstaking_data`, `get_claiming_data`
- module-level `approve_hash_message`

Tests in `tests/test_protocol_unit2.py::TestEthSafeTxBuilderStakingDataMethods` now assert `data` is `bytes` after these calls (previously only checked `to`), since `EthSafeTxBuilder.settle()` itself is `# pragma: no cover`.

### tox.ini cleanup

Removed `commands_pre = poetry install` workarounds (per @OjusWiZard) from `[testenv:pylint]`, `[testenv:unit-tests]`, `[testenv:unit-tests-coverage]`, `[testenv:integration-tests]`. With deps declared explicitly in `pyproject.toml`, tox handles install via the standard path.

## Test plan

- [x] `poetry lock` resolves cleanly
- [x] `poetry run tox -p -e flake8 -e pylint -e black-check -e isort-check -e mypy -e bandit -e safety` — all green
- [x] `poetry run tox -e unit-tests-coverage` — green (`--cov-fail-under=100` satisfied)
- [x] Smoke-imported every operate module that touches the newly-explicit deps
- [x] Bytes-coercion fix applied at all ~19 multisend call sites, locked in by unit tests
- [ ] Verify CI passes on push
- [ ] Verify a real agent service deploys & runs end-to-end via Pearl (staking + fund-drain paths)
- [ ] Confirm `pyinstaller` build still produces a working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
