### PR TITLE
chore: bump version to 0.15.15 and update dependencies in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5002,4 +5002,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.15,>=3.10"
-content-hash = "f865505f246d7b6d0c7c2c177b64bedd902d666ea04bee00b101123bf8b19ea1"
+content-hash = "6fe9fd94e616a7e9dbcb5b17a45ff69f6028818f981b4de34da86aae5c7aaa17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.15.14"
+version = "0.15.15"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ operate = "operate.cli:main"
 
 [tool.poetry.dependencies]
 python = "<3.15,>=3.10"
-open-autonomy = {version = "^0.21.13", extras = ["cli"]}
+open-autonomy = {version = "^0.21.13", extras = ["cli", "docker"]}
 open-aea-ledger-cosmos = "^2.1.0"
 open-aea-ledger-ethereum = "^2.1.0"
 open-aea-ledger-ethereum-flashbots = "^2.1.0"
@@ -36,6 +36,14 @@ argon2-cffi = "==23.1.0"
 requests-mock = "^1.12.1"
 multiaddr = "==0.0.9"
 cryptography = "^46.0.3"
+# Direct deps for packages no longer pulled in transitively after the
+# open-autonomy 0.21.19 / open-aea 2.2.1 dependency-footprint trim.
+aiohttp = "^3.10"
+flask = "^3.0"
+werkzeug = "^3.0"
+hexbytes = "^1.2"
+typing_extensions = "^4.12"
+requests = "^2.32"
 
 [tool.poetry.group.development.dependencies]
 tomte = {version = "0.6.1", extras = ["cli"]}


### PR DESCRIPTION
This pull request updates the `olas-operate-middleware` package to version 0.15.15 and addresses dependency management in the `pyproject.toml` file. The most significant changes are the addition of several direct dependencies that are no longer included transitively due to updates in upstream packages, as well as an update to the `open-autonomy` dependency to include the `docker` extra.

Dependency updates and additions:

* Added direct dependencies: `aiohttp`, `flask`, `werkzeug`, `hexbytes`, `typing_extensions`, and `requests` to ensure compatibility after the upstream `open-autonomy` and `open-aea` packages reduced their dependency footprint.
* Updated the `open-autonomy` dependency to include the `docker` extra, in addition to `cli`.

Version bump:

* Bumped the package version from 0.15.14 to 0.15.15.