### PR TITLE
fix(release): use GitHub App token for protected-main push

### DIFF
--- a/.github/workflows/create-production-release.yml
+++ b/.github/workflows/create-production-release.yml
@@ -16,11 +16,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Get App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Get App user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -32,15 +47,13 @@ jobs:
 
       - name: Configure git identity
         run: |
-          # 41898282 is GitHub's stable user ID for github-actions[bot];
-          # the noreply email format is <user_id>+<username>@users.noreply.github.com.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Compute next version
         id: compute
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python scripts/compute_next_version.py | tee /tmp/version.json
           {
@@ -65,16 +78,6 @@ jobs:
         run: |
           git tag "${{ steps.compute.outputs.next_tag }}"
           git push origin "${{ steps.compute.outputs.next_tag }}"
-
-      - name: Get App token
-        # Used so the release event has an external actor — releases created
-        # by the default GITHUB_TOKEN do not trigger downstream workflows
-        # (release.yml will not fire), per GitHub's anti-loop guard.
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## Summary

- Failing run: https://github.com/valory-xyz/olas-operate-middleware/actions/runs/25128711088
- The Create Production Release workflow pushed the version bump under `github-actions[bot]`, which the `main` branch ruleset rejects with `GH013` ("Changes must be made through a pull request").
- The App-token step already existed in the workflow but only ran after the push, used for the release-create call. Moves it to the top, uses its token for `actions/checkout` (so it's persisted as the push credential), and sets git identity as `<app-slug>[bot]` so the bump push, tag push, and release creation all run as the App.

## Required outside this PR

- The App referenced by `secrets.APP_ID` must be on the `main` ruleset bypass list (Settings → Rules). Without bypass, this still fails with `GH013` — just under the App's identity.
- The App installation must have `contents: write` (push, tag, release create) and `pull-requests: read` (used by `scripts/compute_next_version.py` via `gh pr list`).

## Test plan

- [ ] Confirm App is on the `main` ruleset bypass list
- [ ] Confirm App installation has `contents: write` and `pull-requests: read`
- [ ] Manually dispatch the Create Production Release workflow and verify push to `main` succeeds, tag is pushed, release is created, and `release.yml` fires downstream