### PR TITLE
chore: residual tomte 0.6.1 → 0.7.0 bumps missed by #432

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt-get autoremove
         sudo apt-get autoclean
-        pip install tomte[tox]==0.6.1
+        pip install tomte[tox]==0.7.0
         pip install --user --upgrade setuptools
         sudo npm install -g markdown-spellcheck
     - name: All pre-test checks
@@ -77,7 +77,7 @@ jobs:
         env:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.7.0
           tox -e unit-tests
 
   coverage:
@@ -99,7 +99,7 @@ jobs:
         env:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.7.0
           tox -e unit-tests-coverage
 
       - name: Upload coverage to Codecov
@@ -149,5 +149,5 @@ jobs:
           POETRY_EXE: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.local\\bin\\poetry.exe' || 'poetry' }}
           PYTEST_XDIST_WORKERS: "8"
         run: |
-          pip install tomte[tox]==0.6.1
+          pip install tomte[tox]==0.7.0
           tox -e integration-tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -4279,25 +4279,26 @@ markers = {main = "python_version == \"3.10\"", development = "python_full_versi
 
 [[package]]
 name = "tomte"
-version = "0.6.1"
+version = "0.7.0"
 description = "A library that wraps many useful tools (linters, analysers, etc) to keep Python code clean, secure, well-documented and optimised."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["development"]
 files = [
-    {file = "tomte-0.6.1-py3-none-any.whl", hash = "sha256:3fdd83a7f38bc3a43aa5ce24a2ce84c9a34904cf5887bff06c9cb781024ac59f"},
-    {file = "tomte-0.6.1.tar.gz", hash = "sha256:1e039fd94b1fdd0202c7a4dc01e9324e3786fb2ff18ac5bb6cce142edf9f779e"},
+    {file = "tomte-0.7.0-py3-none-any.whl", hash = "sha256:b127c7a14ca07a89d5fbb2c82b9d9ba581f13aee4f082a98261c794e589e1ab4"},
+    {file = "tomte-0.7.0.tar.gz", hash = "sha256:863e2144aefb13dd988b1c6650167469a82945aa445320d4a4ade41b2edf75e5"},
 ]
 
 [package.dependencies]
 click = {version = "8.3.1", optional = true, markers = "extra == \"black\" or extra == \"cli\" or extra == \"docs\""}
 requests = {version = "2.32.5", optional = true, markers = "extra == \"cli\""}
+tomli = {version = ">=2.0,<3", optional = true, markers = "python_version < \"3.11\" and extra == \"cli\""}
 tox = {version = "4.46.0", optional = true, markers = "extra == \"cli\" or extra == \"tox\""}
 
 [package.extras]
 bandit = ["bandit (==1.9.3)"]
 black = ["black (==26.1.0)", "click (==8.3.1)"]
-cli = ["click (==8.3.1)", "requests (==2.32.5)", "tox (==4.46.0)"]
+cli = ["click (==8.3.1)", "requests (==2.32.5)", "tomli (>=2.0,<3) ; python_version < \"3.11\"", "tox (==4.46.0)"]
 darglint = ["darglint (==1.8.1)"]
 docs = ["Markdown (==3.10.2)", "Pygments (==2.19.2)", "bs4 (==0.0.2)", "click (==8.3.1)", "markdown-include (==0.8.1)", "mkdocs (==1.6.1)", "mkdocs-macros-plugin (==1.5.0)", "mkdocs-material (==9.7.3)", "mkdocs-material-extensions (==1.3.1)", "mkdocs-redirects (==1.2.2)", "pydoc-markdown (==4.8.2)", "pydocstyle (==6.3.0)", "pymdown-extensions (==10.21)"]
 flake8 = ["flake8 (==7.3.0)", "flake8-bugbear (==25.11.29)", "flake8-docstrings (==1.7.0)", "flake8-eradicate (==1.5.0)", "flake8-isort (==7.0.0)", "flake8-pytest-style (==2.2.0)", "pydocstyle (==6.3.0)"]
@@ -5000,4 +5001,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.15,>=3.10"
-content-hash = "e7fa0d504403b38f75927432ff108430d71ad77ea9aa35cc9d5334593f4f35e6"
+content-hash = "689e889aec0fd02a730ac3c71702bb4ecf12fcb1defffa482b7a3af8d9c7b435"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ typing_extensions = "^4.12"
 requests = "^2.32"
 
 [tool.poetry.group.development.dependencies]
-tomte = {version = "0.6.1", extras = ["cli"]}
+tomte = {version = "0.7.0", extras = ["cli"]}
 build = "1.2.2.post1"
 yappi = "^1.6.10"
 viztracer = "^1.1.1"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv = *
 skipsdist = True
 skip_install = True
 deps =
-    tomte[bandit]==0.6.1
+    tomte[bandit]==0.7.0
 commands =
     bandit -r operate -x */tests/*
     bandit -s B101 -r tests
@@ -19,7 +19,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.6.1
+    tomte[black]==0.7.0
 commands =
     black operate tests --exclude operate/data
 
@@ -27,7 +27,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.6.1
+    tomte[black]==0.7.0
 commands =
     black --check operate tests --exclude operate/data
 
@@ -35,7 +35,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.6.1
+    tomte[isort]==0.7.0
 commands =
     isort operate/ tests/ --profile black --skip operate/data
 
@@ -43,7 +43,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.6.1
+    tomte[isort]==0.7.0
 commands =
     isort --check-only --profile black --gitignore operate/ tests/ --skip operate/data
 
@@ -51,7 +51,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[flake8]==0.6.1
+    tomte[flake8]==0.7.0
 commands =
     flake8 operate tests
 
@@ -59,7 +59,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[mypy]==0.6.1
+    tomte[mypy]==0.7.0
     types-cryptography  # TODO backport to tomte repository
 commands =
     mypy operate/ tests/ --disallow-untyped-defs --config-file tox.ini
@@ -71,7 +71,7 @@ allowlist_externals = poetry
 commands_pre = 
     poetry install
 deps =
-    tomte[pylint]==0.6.1
+    tomte[pylint]==0.7.0
 commands =
     pylint operate -j 0 --rcfile=.pylintrc
 
@@ -79,7 +79,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[safety]==0.6.1
+    tomte[safety]==0.7.0
     typer<0.17.0  # remove after this is fixed https://github.com/pyupio/safety/issues/784
 commands =
     safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599 -i 70612
@@ -88,7 +88,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[vulture]==0.6.1
+    tomte[vulture]==0.7.0
 commands =
     vulture operate/services scripts/whitelist.py
 
@@ -96,7 +96,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[darglint]==0.6.1
+    tomte[darglint]==0.7.0
 commands =
     darglint operate tests
 
@@ -118,7 +118,7 @@ commands =
 [testenv:liccheck]
 skipsdist = True
 usedevelop = True
-deps = tomte[liccheck,cli]==0.6.1
+deps = tomte[liccheck,cli]==0.7.0
 commands =
     tomte freeze-dependencies --output-path {envtmpdir}/requirements.txt
     liccheck -s tox.ini -r {envtmpdir}/requirements.txt -l PARANOID
@@ -129,7 +129,7 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.7.0
 commands =
     pytest -p no:pytest_anchorpy -m "not integration" -v --durations=100 {posargs:tests/}
 
@@ -139,7 +139,7 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.7.0
 commands =
     pytest -p no:pytest_anchorpy -m "not integration" -v --durations=100 --cov=operate --cov-report=xml --cov-report=term-missing --cov-fail-under=100 {posargs:tests/}
 
@@ -149,14 +149,14 @@ commands_pre =
     {env:POETRY_EXE:poetry} install
 skip_install = True
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.7.0
     pytest-xdist==3.8.0
 commands =
     pytest -p no:pytest_anchorpy -m "integration" -n {env:PYTEST_XDIST_WORKERS:auto} --dist {env:PYTEST_XDIST_DIST:worksteal} -v --durations=100 {posargs:tests/}
 
 [testenv:all-tests]
 deps =
-    tomte[tests]==0.6.1
+    tomte[tests]==0.7.0
     httpx
     pytest-recording
 commands =


### PR DESCRIPTION
## Summary

Rebased on top of [#432](https://github.com/valory-xyz/olas-operate-middleware/pull/432), which already covers the open-autonomy `^0.21.21` and open-aea `^2.2.5` bumps, the anchorpy-pytest-plugin disable, and the flashbots removal.

After rebase this PR is **one commit ahead** of #432 and addresses the `tomte 0.6.1 → 0.7.0` bump sites #432 missed.

## What's left after rebase

| Site | Why #432 missed it |
| ---- | ------------------ |
| `pyproject.toml` — `[tool.poetry.group.development.dependencies] tomte = "0.6.1"` | #432 bumped the project deps but left the dev-group `tomte` pin at 0.6.1 |
| `tox.ini` — 16 `tomte[<extra>]==0.6.1` testenv deps (bandit, black/black-check, isort/isort-check, flake8, mypy, pylint, safety, vulture, darglint, liccheck, tests × 4) | #432 bumped some sections but not all |
| `.github/workflows/common_checks.yml` — 4 inline `pip install tomte[tox]==0.6.1` | #432 didn't touch this file |
| `poetry.lock` | Regenerated to match the bumped `tomte 0.7.0` pin |

Without these, `tomte[tox]==0.6.1` in CI would still resolve old wheels, and the local tox envs (every linter / type / security / test env) would still install the 0.6.1 stack — diverging from what `tomte` ships in the project deps post-#432. Locally that's silent drift; in CI it could surface as a config-resolution mismatch once #432 lands.

## Context: why tomte 0.7.0

Per the fleet-wide tomte bump in progress (tomte#46 merged 2026-05-01, 0.7.0 published), and the open-autonomy 0.21.20 upgrading guide:

> `tomte 0.6.5 → 0.7.0`. Tomte 0.7.0 ships canonical lint configs (`bandit.yaml`, `darglint.cfg`, `flake8.cfg`, `gitleaks.toml`, `pylintrc`, `safety-policy.yml`, `isort.cfg`) as packaged resources … drops the `tomte check-spelling` CLI.

All open-autonomy / open-aea upstream repos pin `tomte==0.7.0` at OA 0.21.20+ — middleware should match.

## Test plan

- [x] `poetry install` succeeds, no diff vs lockfile
- [x] `poetry run tox -p -e black-check -e isort-check -e flake8 -e mypy -e bandit` — all green
- [x] Smoke imports OK: `autonomy 0.21.21`, `aea 2.2.5`
- [x] CI green on the rebased branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>