### PR TITLE
ci: add "All checks passed" aggregate gate for branch protection

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -151,3 +151,21 @@ jobs:
         run: |
           pip install tomte[tox]==0.6.1
           tox -e integration-tests
+
+  all-checks-passed:
+    # Single aggregate gate referenced by branch protection on `main`.
+    # When adding/removing mandatory jobs, update `needs` here instead of editing branch protection.
+    name: All checks passed
+    needs:
+      - linter_checks
+      - unit-tests
+      - coverage
+      - integration-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          echo "$results" | python -c "import json,sys; r=json.load(sys.stdin); failed=[k for k,v in r.items() if v['result']!='success']; sys.exit(0 if not failed else (print('Failed jobs:', failed) or 1))"


### PR DESCRIPTION
## Summary
- Adds an `all-checks-passed` meta job to `common_checks.yml` that fans in `needs` from `linter_checks`, `unit-tests`, `coverage`, and `integration-tests`.
- Uses `if: always()` and fails if any dependency is non-success (failed/cancelled/skipped).
- Enables branch protection on `main` to require a single `All checks passed` context, so adding/removing mandatory jobs is a workflow edit rather than a branch-protection edit.

## Why
Aligns this repo with the Valory default GitHub repo settings (single aggregate gate). Once merged, branch protection on `main` will be applied to require this context.

## Test plan
- [ ] Verify the `All checks passed` job appears in the PR's checks list and turns green only after the other four jobs succeed.
- [ ] (Post-merge) Apply branch protection on `main` with required context `All checks passed`, strict=true, 2 reviews, dismiss stale, conversation resolution, no force pushes / deletions.

Generated with [Claude Code](https://claude.com/claude-code)
