### PR TITLE
refactor(protocol): consolidate multisend bytes-coercion + add named env-var regression tests

### DIFF
--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -58,7 +58,6 @@ from autonomy.chain.tx import TxSettler
 from autonomy.cli.helpers.chain import MintHelper, OnChainHelper
 from autonomy.cli.helpers.chain import ServiceHelper as ServiceManager
 from eth_utils import to_bytes
-from hexbytes import HexBytes
 from web3.contract import Contract
 from web3.types import TxReceipt
 
@@ -94,6 +93,32 @@ from operate.wallet.master import MasterWallet
 ETHEREUM_ERC20 = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 
 
+def _normalize_tx_data_to_bytes(data: t.Union[str, bytes]) -> bytes:
+    """Coerce a multisend tx ``data`` field to ``bytes``.
+
+    ``Contract.encode_abi()`` returns ``HexStr`` (``str``) under web3 7.x /
+    open-aea 2.2.x, but the multisend contract's ``encode_data()`` requires
+    ``bytes`` for concatenation. This helper handles both ``"0x..."`` and
+    raw-hex inputs as well as already-``bytes`` values.
+
+    Two callsite layers exist for this normalization, covering different
+    paths to multisend:
+
+    - Boundary: :meth:`GnosisSafeTransaction.build` normalizes every tx added
+      via :meth:`GnosisSafeTransaction.add` before passing them to
+      ``multisend.get_tx_data``. This catches all ``gst.add(...).settle()``
+      flows (staking / unstaking / claiming / etc.).
+    - Per-callsite: helpers that bypass :meth:`build` and call
+      ``multisend.get_multisend_tx`` / ``get_tx_data`` directly (e.g.
+      :meth:`get_safe_b_erc20_transfer_messages`) must normalize their own
+      ``txs`` dicts before the multisend call.
+    """
+    if isinstance(data, bytes):
+        return data
+    hex_str = data[2:] if data.startswith("0x") else data
+    return bytes.fromhex(hex_str)
+
+
 class StakingState(Enum):
     """Staking state enumeration for the staking."""
 
@@ -126,16 +151,13 @@ class GnosisSafeTransaction:
 
     def build(self) -> t.Dict:
         """Build the transaction."""
-        # Normalize tx data fields to bytes — encode_abi() may return
-        # HexStr (str) depending on the web3/open-autonomy version, but
-        # the multisend contract's encode_data() requires bytes.
+        # Boundary normalization: every tx added via .add() is coerced to
+        # bytes here before reaching multisend.get_tx_data(). See
+        # _normalize_tx_data_to_bytes for the architectural rationale.
         normalized_txs = []
         for tx in self._txs:
             tx_copy = dict(tx)
-            data = tx_copy.get("data", b"")
-            if isinstance(data, str):
-                hex_str = data[2:] if data.startswith("0x") else data
-                tx_copy["data"] = bytes.fromhex(hex_str)
+            tx_copy["data"] = _normalize_tx_data_to_bytes(tx_copy.get("data", b""))
             normalized_txs.append(tx_copy)
 
         multisend_data = bytes.fromhex(
@@ -981,7 +1003,7 @@ class _ChainUtil:
                 "operation": MultiSendOperation.CALL,
                 "to": multisig,
                 "value": 0,
-                "data": HexBytes(txd[2:]),
+                "data": _normalize_tx_data_to_bytes(txd),
             }
         )
         multisend_txd = registry_contracts.multisend.get_tx_data(  # type: ignore
@@ -1681,18 +1703,15 @@ class EthSafeTxBuilder(_ChainUtil):
             contract_address=token,
         )
 
-        transfer_data = erc20_instance.encode_abi(
-            abi_element_identifier="transfer",
-            args=[to, amount],
-        )
-        # Normalize to bytes — encode_abi() may return HexStr (str)
-        # depending on the web3/open-autonomy version, but the
-        # multisend contract's encode_data() requires bytes.
-        if isinstance(transfer_data, str):
-            hex_str = (
-                transfer_data[2:] if transfer_data.startswith("0x") else transfer_data
+        # Per-callsite normalization: this multisend call bypasses
+        # GnosisSafeTransaction.build() (the boundary), so the tx dict
+        # must be coerced to bytes here. See _normalize_tx_data_to_bytes.
+        transfer_data = _normalize_tx_data_to_bytes(
+            erc20_instance.encode_abi(
+                abi_element_identifier="transfer",
+                args=[to, amount],
             )
-            transfer_data = bytes.fromhex(hex_str)
+        )
 
         txs = []
         txs.append(
@@ -2065,12 +2084,10 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
         txs.append(
             {
                 "to": multisig_address,
-                "data": HexBytes(
-                    bytes.fromhex(
-                        multisig_instance.encode_abi(
-                            abi_element_identifier="addOwnerWithThreshold",
-                            args=[_owner, 1],
-                        )[2:]
+                "data": _normalize_tx_data_to_bytes(
+                    multisig_instance.encode_abi(
+                        abi_element_identifier="addOwnerWithThreshold",
+                        args=[_owner, 1],
                     )
                 ),
                 "operation": MultiSendOperation.CALL,
@@ -2081,12 +2098,10 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
     txs.append(
         {
             "to": multisig_address,
-            "data": HexBytes(
-                bytes.fromhex(
-                    multisig_instance.encode_abi(
-                        abi_element_identifier="removeOwner",
-                        args=[new_owners[0], master_safe, 1],
-                    )[2:]
+            "data": _normalize_tx_data_to_bytes(
+                multisig_instance.encode_abi(
+                    abi_element_identifier="removeOwner",
+                    args=[new_owners[0], master_safe, 1],
                 )
             ),
             "operation": MultiSendOperation.CALL,
@@ -2097,12 +2112,10 @@ def get_reuse_multisig_from_safe_payload(  # pylint: disable=too-many-locals  # 
     txs.append(
         {
             "to": multisig_address,
-            "data": HexBytes(
-                bytes.fromhex(
-                    multisig_instance.encode_abi(
-                        abi_element_identifier="changeThreshold",
-                        args=[threshold],
-                    )[2:]
+            "data": _normalize_tx_data_to_bytes(
+                multisig_instance.encode_abi(
+                    abi_element_identifier="changeThreshold",
+                    args=[threshold],
                 )
             ),
             "operation": MultiSendOperation.CALL,

--- a/poetry.lock
+++ b/poetry.lock
@@ -5001,4 +5001,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.15,>=3.10"
-content-hash = "689e889aec0fd02a730ac3c71702bb4ecf12fcb1defffa482b7a3af8d9c7b435"
+content-hash = "ab391a88e6e5846f701ba47c138df18cb6df18a585ab49d2aa183e54b86d9aff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.15.18"
+version = "0.15.19"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"
@@ -40,7 +40,6 @@ cryptography = "^46.0.3"
 aiohttp = "^3.10"
 flask = "^3.0"
 werkzeug = "^3.0"
-hexbytes = "^1.2"
 typing_extensions = "^4.12"
 requests = "^2.32"
 

--- a/tests/test_bridge_providers.py
+++ b/tests/test_bridge_providers.py
@@ -28,7 +28,6 @@ from unittest.mock import patch
 import pytest
 from aea.helpers.logging import setup_logger
 from deepdiff import DeepDiff
-from hexbytes import HexBytes
 from web3 import Web3
 
 from operate.bridge.bridge_manager import (
@@ -555,13 +554,9 @@ def get_transfer_amount(
                 and Web3.to_checksum_address("0x" + log["topics"][2].to_0x_hex()[-40:])
                 == recipient
             ):
-                data = log["data"]
-                value = (
-                    int(data.to_0x_hex(), 16)
-                    if isinstance(data, HexBytes)
-                    else int(data, 16)
-                )
-                return value
+                # Web3.to_hex accepts bytes/HexBytes/int/str uniformly,
+                # so we don't need an isinstance dispatch on log["data"].
+                return int(Web3.to_hex(log["data"]), 16)
         return 0
 
 

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -31,6 +31,7 @@ from operate.services.protocol import (
     MintManager,
     StakingManager,
     StakingState,
+    _normalize_tx_data_to_bytes,
 )
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,36 @@ class TestStakingState:
         assert StakingState(0) == StakingState.UNSTAKED
         assert StakingState(1) == StakingState.STAKED
         assert StakingState(2) == StakingState.EVICTED
+
+
+# ---------------------------------------------------------------------------
+# _normalize_tx_data_to_bytes helper
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTxDataToBytes:
+    """Tests for the multisend tx data normalization helper."""
+
+    def test_passes_bytes_through_unchanged(self) -> None:
+        """Bytes input is returned as-is."""
+        data = b"\x12\x34\x56"
+        assert _normalize_tx_data_to_bytes(data) is data
+
+    def test_converts_hex_string_with_0x_prefix(self) -> None:
+        """Hex string with ``0x`` prefix is decoded to bytes."""
+        assert _normalize_tx_data_to_bytes("0xdeadbeef") == b"\xde\xad\xbe\xef"
+
+    def test_converts_raw_hex_string_without_prefix(self) -> None:
+        """Hex string without ``0x`` prefix is decoded to bytes."""
+        assert _normalize_tx_data_to_bytes("deadbeef") == b"\xde\xad\xbe\xef"
+
+    def test_handles_empty_string(self) -> None:
+        """Empty string converts to empty bytes."""
+        assert _normalize_tx_data_to_bytes("") == b""
+
+    def test_handles_empty_bytes(self) -> None:
+        """Empty bytes pass through."""
+        assert _normalize_tx_data_to_bytes(b"") == b""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_service_unit2.py
+++ b/tests/test_service_unit2.py
@@ -357,6 +357,133 @@ class TestServiceHelper:
 
 
 # ---------------------------------------------------------------------------
+# Regression: named env-var placeholders in Pearl deployments
+# ---------------------------------------------------------------------------
+
+
+class TestPearlNamedEnvVarRegression:
+    """Pin the upstream contract for Pearl named env-var placeholders.
+
+    Background: PR #432 removed a middleware-side workaround
+    (``_inject_named_env_vars_into_agent_json``) that was injecting named
+    placeholder defaults into ``agent.json`` after generation. Removal was
+    justified by open-autonomy 0.21.20
+    ([#2494](https://github.com/valory-xyz/open-autonomy/pull/2494)) shipping
+    ``Service._extract_named_env_var_defaults`` and merging the surfaced
+    names into the env-var dict inside ``process_component_overrides``.
+
+    These tests fail loudly if the upstream contract regresses, so the
+    Pearl-shaped named-template path (e.g. market-creator / market-resolver
+    using fully-qualified ``SKILL_*`` / ``CONNECTION_*`` names) keeps
+    working without re-introducing the middleware workaround.
+    """
+
+    def test_extract_named_env_var_defaults_finds_named_placeholders(self) -> None:
+        """Surface ``{NAME: default}`` for every Pearl-shaped placeholder.
+
+        Walks the override tree (top-level or deeply nested) and pulls out
+        each ``${NAME:type:default}`` entry by name.
+        """
+        from autonomy.configurations.base import Service as AutonomyService
+
+        pearl_override = {
+            "models": {
+                "params": {
+                    "args": {
+                        "message": "${HELLO_WORLD_MESSAGE:str:hi_default}",
+                        "nested": {
+                            "deep_key": "${DEEP_VAR:str:deep_default}",
+                        },
+                    }
+                }
+            },
+            "store_path": "${STORE_PATH:str:/data/store}",
+            "list_field": ["${LIST_VAR:str:list_default}"],
+        }
+
+        result = AutonomyService._extract_named_env_var_defaults(pearl_override)
+
+        assert result == {
+            "HELLO_WORLD_MESSAGE": "hi_default",
+            "DEEP_VAR": "deep_default",
+            "STORE_PATH": "/data/store",
+            "LIST_VAR": "list_default",
+        }
+
+    def test_extract_named_env_var_defaults_ignores_path_only_placeholders(
+        self,
+    ) -> None:
+        """Skip anonymous placeholders that have no leading ``NAME:`` segment.
+
+        Only the path-keyed entry built later by
+        ``generate_env_vars_recursively`` covers those.
+        """
+        from autonomy.configurations.base import Service as AutonomyService
+
+        anonymous_only = {"key": "${str:anon_default}"}
+
+        result = AutonomyService._extract_named_env_var_defaults(anonymous_only)
+
+        assert result == {}
+
+    def test_extract_named_env_var_defaults_handles_missing_default(self) -> None:
+        """Map a placeholder with no inline default (``${NAME:type}``) to ``None``.
+
+        Lets callers decide how to fill it (env override, skip, etc.).
+        """
+        from autonomy.configurations.base import Service as AutonomyService
+
+        no_default = {"key": "${REQUIRED_VAR:str}"}
+
+        result = AutonomyService._extract_named_env_var_defaults(no_default)
+
+        assert result == {"REQUIRED_VAR": None}
+
+    def test_host_deployment_generator_writes_named_env_vars_to_agent_json(
+        self, tmp_path: Path
+    ) -> None:
+        """Persist named env-var keys all the way to ``agent.json``.
+
+        When ``service_builder.generate_agent`` returns named env-var keys
+        (as upstream does after merging ``_extract_named_env_var_defaults``
+        output into ``env_var_dict``), they must land in ``agent.json`` for
+        the agent runner to consume. Pins the property the removed
+        ``_inject_named_env_vars_into_agent_json`` workaround used to
+        guarantee at the middleware layer.
+        """
+        mock_sb = MagicMock()
+        mock_sb.generate_agent.return_value = {
+            # Path-keyed entry from generate_env_vars_recursively
+            "SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_MESSAGE": "hi_default",
+            # Named placeholder surfaced via _extract_named_env_var_defaults
+            "HELLO_WORLD_MESSAGE": "hi_default",
+            "STORE_PATH": "/data/store",
+            "ITEM_COUNT": 42,
+        }
+        mock_sb.keys = [{"private_key": "0xdeadbeef", "ledger": "ethereum"}]
+        mock_sb.multiledger = False
+
+        gen = HostDeploymentGenerator.__new__(HostDeploymentGenerator)
+        gen.service_builder = mock_sb  # type: ignore[attr-defined]
+        gen.build_dir = tmp_path / "build"  # type: ignore[attr-defined]
+
+        gen.generate()
+
+        agent_json = json.loads(
+            (tmp_path / "build" / "agent.json").read_text(encoding="utf-8")
+        )
+        # Named keys must be present alongside path-keyed entries — without
+        # this Pearl deployments using ${HELLO_WORLD_MESSAGE:str:hi_default}
+        # would silently fall back to YAML defaults at agent boot.
+        assert agent_json["HELLO_WORLD_MESSAGE"] == "hi_default"
+        assert agent_json["STORE_PATH"] == "/data/store"
+        assert agent_json["ITEM_COUNT"] == "42"  # str-coerced by generate()
+        assert (
+            agent_json["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_MESSAGE"] == "hi_default"
+        )
+
+
+# ---------------------------------------------------------------------------
 # tests for HostDeploymentGenerator (generate, _populate_keys, populate_private_keys)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #432 addressing review feedback from @jmoreira-valory.

## Summary

1. **Multisend bytes-coercion canonicalisation** — extracts `_normalize_tx_data_to_bytes` helper documenting the two architectural layers and replaces all 6 ad-hoc normalization sites with the helper. Aligns with [open-autonomy 0.21.19's upgrading guidance](https://github.com/valory-xyz/open-autonomy/blob/main/docs/upgrading.md#v02118-to-v02119) (`hexbytes -- replaced by plain bytes for multisend tx data`).

2. **Pearl named env-var regression coverage** — adds `TestPearlNamedEnvVarRegression` pinning the upstream contract from open-autonomy 0.21.20 [#2494](https://github.com/valory-xyz/open-autonomy/pull/2494) (`Service._extract_named_env_var_defaults`) that lets PR #432 remove the middleware-side `_inject_named_env_vars_into_agent_json` workaround.

3. **Drops the now-unused `hexbytes` direct dep** — only remaining use was an `isinstance(data, HexBytes)` dispatch on web3 log data in `test_bridge_providers.py`, replaced with `Web3.to_hex()` (handles `bytes` / `HexBytes` / `str` uniformly). `hexbytes` stays installed transitively via web3.

4. **Patch bumps middleware** to `0.15.19`.

## Multisend two-layer architecture (now documented in code)

| Path | Sites | Normalization layer |
|---|---|---|
| `gst.add(tx)` → `gst.build()` → `multisend.get_tx_data()` | `get_staking_data` / `get_unstaking_data` / `get_claiming_data`, plus tx dicts returned from `get_safe_b_*_transfer_messages` | **Boundary** in `GnosisSafeTransaction.build()` |
| Direct `multisend.get_multisend_tx()` / `get_tx_data()` (bypasses `build()`) | `get_safe_b_erc20_transfer_messages`, `swap_owner_tx`, `get_reuse_multisig_from_safe_payload` | **Per-callsite** |

The two layers cover **different paths to multisend**, not duplicate work — verified during this PR's investigation. The helper docstring (in `operate/services/protocol.py`) explains the rationale so future maintainers don't get confused again.

## Pearl named env-var regression contract pinned

The 4 new tests in `TestPearlNamedEnvVarRegression` (in `tests/test_service_unit2.py`) fail loudly if any of these regress upstream:
- `_extract_named_env_var_defaults` walks dicts / lists / nested values
- Anonymous (path-only) placeholders are skipped
- Placeholders with no inline default map to `None`
- Named keys land in `agent.json` after `HostDeploymentGenerator.generate()`

If a future open-autonomy bump removes / renames the upstream method, Pearl deployments using `${SKILL_*:str:default}` / `${CONNECTION_*:str:default}` would silently fall back to YAML defaults — these tests catch that at the middleware layer.

## Test plan

- [x] `tox -p -e flake8 -e pylint -e black-check -e isort-check -e mypy -e bandit` — all green
- [x] `tox -e unit-tests` — 1966 passed, 303 deselected
- [x] 5 new unit tests pin `_normalize_tx_data_to_bytes` behaviour
- [x] 4 new regression tests pin the upstream named env-var contract
- [ ] CI integration tests
