### PR TITLE
Potential fix for code scanning alert no. 218: Information exposure through an exception

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -1656,8 +1656,7 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             )
             return JSONResponse(
                 content={
-                    "error": f"Failed to terminate service and withdraw funds. Insufficient funds: {e}",
-                    **e.to_error_fields(),
+                    "error": "Failed to terminate service and withdraw funds due to insufficient funds.",
                 },
                 status_code=HTTPStatus.BAD_REQUEST,
             )


### PR DESCRIPTION
Potential fix for [https://github.com/valory-xyz/olas-operate-middleware/security/code-scanning/218](https://github.com/valory-xyz/olas-operate-middleware/security/code-scanning/218)

To fix this without changing endpoint behavior materially, keep detailed exception info in server logs, but return a **generic client error payload** for the `InsufficientFundsException` path.

Best fix in this file/region:
- In `operate/cli.py`, inside `_terminate_and_withdraw`, update the `except InsufficientFundsException as e` block.
- Keep logging with traceback for operators.
- Replace response `content` so it does **not** include `e` nor `e.to_error_fields()`; return a generic message and keep `HTTPStatus.BAD_REQUEST`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
