### PR TITLE
Potential fix for code scanning alert no. 217: Information exposure through an exception

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -1255,9 +1255,8 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             logger.error(f"Insufficient funds: {e}\n{traceback.format_exc()}")
             return JSONResponse(
                 content={
-                    "error": f"Failed to withdraw funds. Insufficient funds: {e}",
+                    "error": "Failed to withdraw funds due to insufficient funds.",
                     "transfer_txs": transfer_txs,
-                    **e.to_error_fields(),
                 },
                 status_code=HTTPStatus.BAD_REQUEST,
             )


### PR DESCRIPTION
Potential fix for [https://github.com/valory-xyz/olas-operate-middleware/security/code-scanning/217](https://github.com/valory-xyz/olas-operate-middleware/security/code-scanning/217)

General fix: keep detailed exception information in server logs only, and return a generic/safe client-facing error payload that does not include raw exception text or exception-derived fields.

Best fix in this snippet (operate/cli.py, `_wallet_withdraw`, around lines 1254–1262):
- Keep the existing `logger.error(...)` call (or equivalent) for internal diagnostics.
- Change the `InsufficientFundsException` response to remove `f"...{e}"` and remove `**e.to_error_fields()` from the JSON payload.
- Return a stable, generic error message for the client (for example, “Failed to withdraw funds due to insufficient funds.”), while preserving status code and `transfer_txs` so functionality/shape remains mostly intact.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
