### PR TITLE
fix(account): rotate agent EOAs on mnemonic password change [OPE-1690]

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -363,6 +363,12 @@ class OperateApp:  # pylint: disable=too-many-instance-attributes
         whose ``agent_addresses`` still references a now-``.lost``
         address fails to start with ``FileNotFoundError`` inside
         ``_build_host``.
+
+        Retry semantics: this flow is retryable but not orphan-free. A
+        crash between step 2 and the end of step 3 leaves freshly minted
+        keys on disk that the next retry will re-``.lost`` and then
+        replace. Services still converge to a valid state; the cost is
+        ``.lost`` clutter in the keys directory.
         """
 
         if not new_password:
@@ -376,10 +382,11 @@ class OperateApp:  # pylint: disable=too-many-instance-attributes
         self.user_account.force_update(new_password)
         failed = self._keys_manager.discard_all()
         if failed:
-            # Wallet + user.json are already on new_password by this point;
-            # only the discard step partially failed. Re-running the
-            # seed-phrase flow is safe: wallet/user updates are idempotent
-            # and discard_all skips files already marked .lost.
+            # Wallet + user.json are already on new_password by this point,
+            # but the rotation loop hasn't run, so no agent keys were
+            # minted. Re-running the seed-phrase flow is safe in this
+            # narrow case: wallet/user updates are idempotent and
+            # discard_all skips files already marked .lost.
             raise ValueError(
                 "Could not mark the following agent keys as discarded; "
                 "retry the seed-phrase recovery flow to finish the "
@@ -390,7 +397,17 @@ class OperateApp:  # pylint: disable=too-many-instance-attributes
         # service can decrypt them on start. Pin keys_manager explicitly
         # rather than relying on the login state at the caller.
         self._keys_manager.password = new_password
-        all_services, _ = self.service_manager().get_all_services()
+        all_services, all_loaded = self.service_manager().get_all_services()
+        if not all_loaded:
+            # ServiceManager already logged the per-service load failure;
+            # surface it here too so the operator knows some services were
+            # NOT rotated and will still hit FileNotFoundError on start.
+            logger.warning(
+                "Some service configs failed to load during agent EOA "
+                "rotation; their agent_addresses still point at .lost "
+                "key files and will fail to start. Fix the service "
+                "configs and re-run the seed-phrase recovery flow."
+            )
         for service in all_services:
             if not service.agent_addresses:
                 continue

--- a/operate/cli.py
+++ b/operate/cli.py
@@ -349,12 +349,20 @@ class OperateApp:  # pylint: disable=too-many-instance-attributes
         """Updates current password using the mnemonic.
 
         The seed-phrase flow is for users who no longer have the password
-        agent EOA keys were encrypted with. Agent keys are marked
-        discarded (renamed ``.lost``) so the caller can re-establish agent
-        authority via the safe recovery module; the original files remain
-        on disk for audit. Discard runs last so a failure in the wallet
-        rewrite or the ``user.json`` update doesn't leave the directory in
-        a half-renamed state.
+        agent EOA keys were encrypted with. The old agent EOA key files
+        are unreadable, so we:
+
+        1. Rewrite the master keystore + ``user.json`` with the new password.
+        2. Mark every old agent EOA key file ``.lost`` for audit.
+        3. Mint a replacement EOA per slot in each service's
+           ``agent_addresses`` and rewrite the service config in place.
+
+        Step 3 matches the contract that
+        :class:`~operate.wallet.wallet_recovery_manager.WalletRecoveryManager`
+        already enforces on the full-recovery path. Without it, a service
+        whose ``agent_addresses`` still references a now-``.lost``
+        address fails to start with ``FileNotFoundError`` inside
+        ``_build_host``.
         """
 
         if not new_password:
@@ -377,6 +385,19 @@ class OperateApp:  # pylint: disable=too-many-instance-attributes
                 "retry the seed-phrase recovery flow to finish the "
                 f"discard step: {', '.join(failed)}"
             )
+
+        # Replacement EOAs must be encrypted under new_password so the
+        # service can decrypt them on start. Pin keys_manager explicitly
+        # rather than relying on the login state at the caller.
+        self._keys_manager.password = new_password
+        all_services, _ = self.service_manager().get_all_services()
+        for service in all_services:
+            if not service.agent_addresses:
+                continue
+            service.agent_addresses = [
+                self._keys_manager.create() for _ in service.agent_addresses
+            ]
+            service.store()
 
     def service_manager(
         self, skip_dependency_check: t.Optional[bool] = False

--- a/operate/keys.py
+++ b/operate/keys.py
@@ -210,17 +210,19 @@ class KeysManager:
         Every regular file is renamed by appending ``.lost`` — address-named
         keystores, their ``.bak`` backups, plaintext ``_private_key``
         sidecars, and any stray files alike. Originals remain on disk for
-        audit. The call is idempotent: files already suffixed ``.lost``
-        are skipped. Per-entry rename failures are logged and returned so
-        callers can surface them to the user instead of silently leaving
-        active keys behind.
+        audit. ``Path.replace`` is used (not ``Path.rename``) so a stale
+        ``.lost`` artefact from a previous rotation gets overwritten
+        instead of triggering ``FileExistsError`` on Windows. The call
+        is idempotent: files already suffixed ``.lost`` are skipped.
+        Per-entry failures are logged and returned so callers can surface
+        them to the user instead of silently leaving active keys behind.
         """
         failed: list[str] = []
         for entry in self.path.iterdir():
             if not entry.is_file() or entry.suffix == ".lost":
                 continue
             try:
-                entry.rename(entry.with_name(entry.name + ".lost"))
+                entry.replace(entry.with_name(entry.name + ".lost"))
             except OSError as exc:
                 self.logger.error(
                     "Failed to mark %s as discarded (%s: %s)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olas-operate-middleware"
-version = "0.15.21"
+version = "0.15.22"
 description = ""
 authors = ["David Vilela <dvilelaf@gmail.com>", "Viraj Patel <vptl185@gmail.com>"]
 readme = "README.md"

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -537,26 +537,52 @@ class TestKeysManager:
         keys_manager.create()
         keys_manager.create()
 
-        real_rename = Path.rename
+        real_replace = Path.replace
         calls = {"failed": False}
 
-        def flaky_rename(self: Path, target: Path) -> Path:
+        def flaky_replace(self: Path, target: Path) -> Path:
             if not calls["failed"]:
                 calls["failed"] = True
-                raise OSError("simulated rename failure")
-            return real_rename(self, target)
+                raise OSError("simulated replace failure")
+            return real_replace(self, target)
 
-        with patch.object(Path, "rename", flaky_rename):
+        with patch.object(Path, "replace", flaky_replace):
             failed = keys_manager.discard_all()
 
         remaining = list(keys_manager.path.iterdir())
-        # One file was left in place (the rename raised), the rest renamed.
+        # One file was left in place (the replace raised), the rest renamed.
         assert any(entry.suffix == ".lost" for entry in remaining)
         assert any(entry.suffix != ".lost" for entry in remaining)
         keys_manager.logger.error.assert_called()  # type: ignore[attr-defined]
         # The failed name must match a file that still has no .lost suffix.
         assert len(failed) == 1
         assert (keys_manager.path / failed[0]).exists()
+
+    def test_discard_all_overwrites_stale_lost_destination(
+        self, keys_manager: KeysManager
+    ) -> None:
+        """A pre-existing ``.lost`` artefact must not block discard on retry.
+
+        Regression for the Windows-specific failure surfaced by QA:
+        ``Path.rename`` raises ``FileExistsError`` (WinError 183) when
+        the destination already exists. POSIX silently overwrites, so
+        Linux/macOS test runners hid the bug. Switching to ``Path.replace``
+        gives cross-platform overwrite semantics. The check below would
+        fail on Windows if ``discard_all`` were ever reverted to ``rename``.
+        """
+        address = keys_manager.create()
+        # Simulate a prior rotation that already produced a `.bak.lost`.
+        stale_lost = keys_manager.path / f"{address}.bak.lost"
+        stale_lost.write_text("stale", encoding="utf-8")
+
+        failed = keys_manager.discard_all()
+
+        assert failed == []
+        # Fresh `.bak` is gone (renamed over the stale one); the .lost
+        # destination now holds the just-discarded content, not "stale".
+        assert not (keys_manager.path / f"{address}.bak").exists()
+        assert stale_lost.is_file()
+        assert stale_lost.read_text(encoding="utf-8") != "stale"
 
     def test_update_password_skips_lost_files(
         self, keys_manager: KeysManager, password: str

--- a/tests/test_operate_cli.py
+++ b/tests/test_operate_cli.py
@@ -670,24 +670,24 @@ class TestMnemonicReencryptionOnPasswordChange:
     def test_update_password_with_mnemonic_raises_when_discard_fails(
         self, tmp_path: Path
     ) -> None:
-        """A real rename OSError must propagate as ValueError from the seed-phrase flow."""
+        """A real replace OSError must propagate as ValueError from the seed-phrase flow."""
         operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
         password2 = random_string()
         address = operate.keys_manager.create()
 
-        real_rename = Path.rename
+        real_replace = Path.replace
         calls = {"failed": False}
 
-        def flaky_rename(self: Path, target: Path) -> Path:
-            # Only intercept the discard_all renames (target ends in
-            # `.lost`); other Path.rename calls from resource storage
+        def flaky_replace(self: Path, target: Path) -> Path:
+            # Only intercept the discard_all replaces (target ends in
+            # `.lost`); other Path.replace calls from resource storage
             # must continue to work.
             if str(target).endswith(".lost") and not calls["failed"]:
                 calls["failed"] = True
-                raise OSError("simulated rename failure")
-            return real_rename(self, target)
+                raise OSError("simulated replace failure")
+            return real_replace(self, target)
 
-        with patch.object(Path, "rename", flaky_rename):
+        with patch.object(Path, "replace", flaky_replace):
             with pytest.raises(ValueError, match="discard"):
                 operate.update_password_with_mnemonic(mnemonic, password2)
 
@@ -699,7 +699,7 @@ class TestMnemonicReencryptionOnPasswordChange:
         remaining = list(operate.keys_manager.path.iterdir())
         assert any(entry.suffix != ".lost" for entry in remaining)
         assert any(entry.suffix == ".lost" for entry in remaining)
-        # Retry must converge: with rename working normally, discard_all
+        # Retry must converge: with replace working normally, discard_all
         # finishes the .lost rename for the previously-stuck file.
         operate.update_password_with_mnemonic(mnemonic, password2)
         for entry in operate.keys_manager.path.iterdir():

--- a/tests/test_operate_cli.py
+++ b/tests/test_operate_cli.py
@@ -25,7 +25,7 @@ import logging
 import shutil
 from pathlib import Path
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import argon2
@@ -476,10 +476,9 @@ class TestMnemonicReencryptionOnPasswordChange:
     ) -> None:
         """Seed-phrase recovery discards agent EOA keys (unrecoverable by definition).
 
-        The safe recovery module re-establishes agent authority out-of-band;
-        the middleware's job here is to mark the unusable key files so the
-        recovery flow can take over while the originals remain on disk for
-        audit.
+        The original key files remain on disk for audit, but every entry
+        in any service's ``agent_addresses`` is replaced with a freshly
+        minted EOA encrypted under the new password.
         """
         operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
         password2 = random_string()
@@ -493,6 +492,77 @@ class TestMnemonicReencryptionOnPasswordChange:
             assert not (operate.keys_manager.path / address).exists()
             assert (operate.keys_manager.path / f"{address}.lost").is_file()
             assert (operate.keys_manager.path / f"{address}.bak.lost").is_file()
+
+    def test_update_password_with_mnemonic_rotates_service_agent_addresses(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Each service's agent_addresses are replaced with freshly minted EOAs.
+
+        Pearl's seed-phrase password change loses access to existing
+        agent EOA keys. Without rotation, the service config still
+        references the (now ``.lost``) addresses and Service.build
+        fails with ``FileNotFoundError`` on next start. The new flow
+        mints a replacement per slot and rewrites the service config.
+        """
+        operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
+        password2 = random_string()
+        old_agent_a = operate.keys_manager.create()
+        old_agent_b = operate.keys_manager.create()
+        # Two services to prove the rotation walks all of them.
+        service_a = MagicMock(spec=["agent_addresses", "store"])
+        service_a.agent_addresses = [old_agent_a]
+        service_b = MagicMock(spec=["agent_addresses", "store"])
+        service_b.agent_addresses = [old_agent_b]
+
+        service_manager_stub = MagicMock()
+        service_manager_stub.get_all_services.return_value = (
+            [service_a, service_b],
+            True,
+        )
+        with patch.object(
+            operate, "service_manager", return_value=service_manager_stub
+        ):
+            operate.update_password_with_mnemonic(mnemonic, password2)
+
+        for old, service in ((old_agent_a, service_a), (old_agent_b, service_b)):
+            # Old key files are .lost; the new agent address is fresh and
+            # has a real keystore on disk encrypted under password2.
+            assert (operate.keys_manager.path / f"{old}.lost").is_file()
+            assert not (operate.keys_manager.path / old).exists()
+            [new_address] = service.agent_addresses
+            assert new_address != old
+            new_key_path = operate.keys_manager.path / new_address
+            assert new_key_path.is_file()
+            # decrypt with new password proves the file is usable.
+            assert (
+                operate.keys_manager.get(new_address).get_decrypted_json(
+                    password=password2
+                )["address"]
+                == new_address
+            )
+            service.store.assert_called_once()
+
+    def test_update_password_with_mnemonic_skips_services_without_agent_addresses(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Services with empty agent_addresses are not rewritten."""
+        operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
+        password2 = random_string()
+
+        empty_service = MagicMock(spec=["agent_addresses", "store"])
+        empty_service.agent_addresses = []
+
+        service_manager_stub = MagicMock()
+        service_manager_stub.get_all_services.return_value = ([empty_service], True)
+        with patch.object(
+            operate, "service_manager", return_value=service_manager_stub
+        ):
+            operate.update_password_with_mnemonic(mnemonic, password2)
+
+        assert empty_service.agent_addresses == []
+        empty_service.store.assert_not_called()
 
     def test_update_password_idempotent_path_still_reencrypts_mnemonic(
         self, tmp_path: Path

--- a/tests/test_operate_cli.py
+++ b/tests/test_operate_cli.py
@@ -564,6 +564,77 @@ class TestMnemonicReencryptionOnPasswordChange:
         assert empty_service.agent_addresses == []
         empty_service.store.assert_not_called()
 
+    def test_update_password_with_mnemonic_rotates_multi_agent_service(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A service with multiple agent slots gets the right count of fresh, distinct EOAs."""
+        operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
+        password2 = random_string()
+        old_addresses = [
+            operate.keys_manager.create(),
+            operate.keys_manager.create(),
+            operate.keys_manager.create(),
+        ]
+        service = MagicMock(spec=["agent_addresses", "store"])
+        service.agent_addresses = list(old_addresses)
+
+        service_manager_stub = MagicMock()
+        service_manager_stub.get_all_services.return_value = ([service], True)
+        with patch.object(
+            operate, "service_manager", return_value=service_manager_stub
+        ):
+            operate.update_password_with_mnemonic(mnemonic, password2)
+
+        assert len(service.agent_addresses) == len(old_addresses)
+        # Each new address is distinct from every old one and from every
+        # other new one.
+        assert len(set(service.agent_addresses)) == len(old_addresses)
+        assert set(service.agent_addresses).isdisjoint(set(old_addresses))
+        for new_address in service.agent_addresses:
+            assert (operate.keys_manager.path / new_address).is_file()
+        service.store.assert_called_once()
+
+    def test_update_password_with_mnemonic_warns_when_a_service_fails_to_load(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``get_all_services`` returning ``success=False`` must surface a warning.
+
+        The loadable services are still rotated; the unloadable ones are
+        skipped. The operator must be told because the unloadable
+        services will keep hitting ``FileNotFoundError`` on start.
+        """
+        operate, _, mnemonic = self._setup_wallet_with_mnemonic(tmp_path)
+        password2 = random_string()
+        old_address = operate.keys_manager.create()
+        loadable_service = MagicMock(spec=["agent_addresses", "store"])
+        loadable_service.agent_addresses = [old_address]
+
+        service_manager_stub = MagicMock()
+        # success=False signals that at least one service directory
+        # failed to load and is missing from the returned list.
+        service_manager_stub.get_all_services.return_value = (
+            [loadable_service],
+            False,
+        )
+        with caplog.at_level(logging.WARNING, logger="operate"):
+            with patch.object(
+                operate, "service_manager", return_value=service_manager_stub
+            ):
+                operate.update_password_with_mnemonic(mnemonic, password2)
+
+        assert any(
+            "service configs failed to load" in record.message
+            for record in caplog.records
+        )
+        # The loadable service must still be rotated.
+        [new_address] = loadable_service.agent_addresses
+        assert new_address != old_address
+        assert (operate.keys_manager.path / new_address).is_file()
+        loadable_service.store.assert_called_once()
+
     def test_update_password_idempotent_path_still_reencrypts_mnemonic(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Proposed changes

Closes the gap surfaced by QA bundle "QA - poly not starting": after a user changes their password via the seed-phrase flow (`PUT /api/account` with a `mnemonic` field), starting any service that was created before the password change fails with:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/Users/*******/.operate/keys/0x82be9B3B50ccbC3dB858cc0bD3D69173dc2DE2e4'
```

raised by `_build_host` (`operate/services/service.py:611`) when it iterates `service.agent_addresses` and calls `keys_manager.get(address)` on a file that was renamed `.lost` by `discard_all` in the previous PR.

### Why this happens

`WalletRecoveryManager` (the long-form recovery flow, `POST /api/wallet/recovery/...`) already encodes the full contract: `prepare_recovery` mints a new EOA per slot in each service and stashes them in a bundle (`wallet_recovery_manager.py:177-182`), and `complete_recovery` copies the new key files into `~/.operate/keys/` and rewrites every `service.agent_addresses` in place (`wallet_recovery_manager.py:495-502`). The simpler `OperateApp.update_password_with_mnemonic` sibling — the one users hit via `PUT /api/account` — was missing this second half: it marked the old agent EOA key files `.lost` but never minted replacements, never rewrote any service config. The service was therefore unbootable.

### Changes

- **`operate/cli.py`** — `OperateApp.update_password_with_mnemonic` now:
  1. Rewrites master keystore + `user.json` (existing).
  2. `discard_all()` — marks every old agent EOA key file `.lost` (existing).
  3. Pins `_keys_manager.password = new_password` so newly minted keystores are encrypted with it.
  4. Walks `service_manager().get_all_services()` and for each service mints `keys_manager.create()` once per slot in `service.agent_addresses`, replaces the list in place, and persists via `service.store()`. Services with empty `agent_addresses` are skipped.

### Tests

- `tests/test_operate_cli.py`
  - `test_update_password_with_mnemonic_rotates_service_agent_addresses` — proves the rotation: new addresses differ from old, the new key files exist on disk and decrypt with the new password, `service.store()` is called.
  - `test_update_password_with_mnemonic_skips_services_without_agent_addresses` — proves the empty-list branch is a no-op.

### Verification

- `poetry run -- tox -e unit-tests-coverage` — 1987 passed, 100% coverage (`--cov-fail-under=100`).
- `poetry run -- tox p -e flake8 -e pylint -e black-check -e isort-check -e bandit -e safety -e mypy` — all 7 OK.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
