### PR TITLE
fix: free fixed agent/tendermint ports to break agent restart deadlock (OPE-1756)

### DIFF
--- a/operate/constants.py
+++ b/operate/constants.py
@@ -67,10 +67,13 @@ BRIDGE_GAS_ESTIMATE_MULTIPLIER = 1.2
 MIN_PASSWORD_LENGTH = 8
 DEFAULT_FUNDING_REQUESTS_COOLDOWN_SECONDS = 300  # Seconds to wait after an agent has been funded during which it will not be asked for fund requirements again
 
-HEALTH_CHECK_URL = "http://127.0.0.1:8716/healthcheck"  # possible DNS issues on windows so use IP address
-AGENT_FUNDS_STATUS_URL = "http://127.0.0.1:8716/funds-status"
+AGENT_HTTP_PORT = 8716  # agent HTTP server (healthcheck / funds-status)
+TENDERMINT_COM_PORT = 8080  # Tendermint manager (flask) control server
+
+HEALTH_CHECK_URL = f"http://127.0.0.1:{AGENT_HTTP_PORT}/healthcheck"  # possible DNS issues on windows so use IP address
+AGENT_FUNDS_STATUS_URL = f"http://127.0.0.1:{AGENT_HTTP_PORT}/funds-status"
 SAFE_WEBAPP_URL = "https://app.safe.global/home?safe=gno:"
-TM_CONTROL_URL = "http://localhost:8080"
+TM_CONTROL_URL = f"http://localhost:{TENDERMINT_COM_PORT}"
 IPFS_ADDRESS = "https://gateway.autonolas.tech/ipfs/f01701220{hash}"
 
 # TODO: These links may break in the future, use a more robust approach

--- a/operate/services/deployment_runner.py
+++ b/operate/services/deployment_runner.py
@@ -442,10 +442,11 @@ class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
     def _start(self, password: str) -> None:
         """Start the deployment."""
         self.logger.info("Starting the deployment")
-        self._setup_agent(password=password)
-        # A leftover process (prior run, or a failed earlier _start attempt) may
-        # still hold the fixed ports; binding would then fail with OSError 10048.
+        # Reap leftovers first (prior run, or a failed earlier _start attempt):
+        # a process still holding a fixed port would make binding fail with
+        # OSError 10048. Done before setup so nothing survives into the bind.
         self._free_deployment_ports()
+        self._setup_agent(password=password)
         if self._is_aea:
             self._start_tendermint()
 
@@ -473,6 +474,9 @@ class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
             return
         # read_pid_file removes the file when stale, so capture the PID first.
         raw_pid = read_raw_pid(pid_file)
+        # TOCTOU: raw_pid could be recycled by the OS between this read and the
+        # kill below (both branches). The port-reap backstop in the caller covers
+        # the practical case where the original process already died.
         try:
             pid = read_pid_file(
                 pid_file,

--- a/operate/services/deployment_runner.py
+++ b/operate/services/deployment_runner.py
@@ -21,6 +21,7 @@
 
 import ctypes
 import json
+import logging
 import multiprocessing
 import os
 import platform
@@ -49,6 +50,7 @@ from operate.utils.pid_file import (
     PIDFileError,
     StalePIDFile,
     read_pid_file,
+    read_raw_pid,
     remove_pid_file,
     write_pid_file,
 )
@@ -103,6 +105,39 @@ def kill_process(pid: int) -> None:
         _kill_process(child.pid)
     _kill_process(pid)
     _kill_process(pid)
+
+
+def kill_processes_on_port(port: int, logger: logging.Logger) -> None:
+    """Kill any local process listening on the given TCP port.
+
+    Backstop for PID-file tracking misses (PID reuse, unexpected process name,
+    orphaned child): only one agent owns the fixed ports at a time, so whatever
+    listens on one is the blocker preventing the next agent from binding.
+
+    ``net_connections`` needs root on macOS and raises ``AccessDenied`` for an
+    unprivileged process, so the reap is silently skipped there.
+    """
+    own_pid = os.getpid()
+    try:
+        connections = psutil.net_connections(kind="inet")
+    except (psutil.AccessDenied, OSError) as e:
+        logger.warning(f"Could not enumerate connections to free port {port}: {e}")
+        return
+
+    pids = {
+        conn.pid
+        for conn in connections
+        if conn.pid not in (None, own_pid)
+        and conn.status == psutil.CONN_LISTEN
+        and conn.laddr
+        and conn.laddr.port == port
+    }
+    for pid in pids:
+        logger.warning(
+            f"Port {port} is held by leftover process PID {pid}; "
+            f"killing it to free the port for the deployment"
+        )
+        kill_process(pid)
 
 
 class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
@@ -408,6 +443,9 @@ class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
         """Start the deployment."""
         self.logger.info("Starting the deployment")
         self._setup_agent(password=password)
+        # A leftover process (prior run, or a failed earlier _start attempt) may
+        # still hold the fixed ports; binding would then fail with OSError 10048.
+        self._free_deployment_ports()
         if self._is_aea:
             self._start_tendermint()
 
@@ -420,28 +458,55 @@ class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
         if self._is_aea:
             self._stop_tendermint()
 
+    def _terminate_recorded_process(
+        self,
+        pid_file: Path,
+        expected_process_names: List[str],
+        label: str,
+    ) -> None:
+        """Terminate the process recorded in a PID file and remove the file.
+
+        Validation can flag a live process as stale on a mere name mismatch;
+        We kill the recorded PID on the stale path when it is still alive.
+        """
+        if not pid_file.exists():
+            return
+        # read_pid_file removes the file when stale, so capture the PID first.
+        raw_pid = read_raw_pid(pid_file)
+        try:
+            pid = read_pid_file(
+                pid_file,
+                expected_process_names=expected_process_names,
+                remove_stale=True,
+            )
+            kill_process(pid)
+        except (FileNotFoundError, StalePIDFile):
+            if raw_pid is not None and psutil.pid_exists(raw_pid):
+                self.logger.warning(
+                    f"{label} PID {raw_pid} flagged stale but alive; killing it"
+                )
+                kill_process(raw_pid)
+        except PIDFileError as e:
+            self.logger.error(f"Error reading {label} PID file {pid_file}: {e}")
+            if raw_pid is not None and psutil.pid_exists(raw_pid):
+                kill_process(raw_pid)
+        finally:
+            remove_pid_file(pid_file, force=True)
+
+    def _free_deployment_ports(self) -> None:
+        """Reap leftover processes holding this deployment's fixed local ports."""
+        kill_processes_on_port(constants.AGENT_HTTP_PORT, logger=self.logger)
+        if self._is_aea:
+            kill_processes_on_port(constants.TENDERMINT_COM_PORT, logger=self.logger)
+
     def _stop_agent(self) -> None:
         """Stop agent process using safe PID file operations."""
-        pid_file = self._work_directory / "agent.pid"
-        if pid_file.exists():
-            try:
-                # Read and validate PID (checks process exists, removes stale files)
-                # Expected process names: python, agent_runner, aea
-                pid = read_pid_file(
-                    pid_file,
-                    expected_process_names=["python", "agent", "aea"],
-                    remove_stale=True,
-                )
-                kill_process(pid)
-                # Clean up PID file after successful kill
-                remove_pid_file(pid_file, force=True)
-            except (FileNotFoundError, StalePIDFile):
-                # PID file doesn't exist or process already dead - OK
-                self.logger.debug(f"Agent PID file {pid_file} not found or stale")
-            except PIDFileError as e:
-                self.logger.error(f"Error reading agent PID file {pid_file}: {e}")
-                # Try to clean up invalid PID file
-                remove_pid_file(pid_file, force=True)
+        self._terminate_recorded_process(
+            self._work_directory / "agent.pid",
+            expected_process_names=["python", "agent", "aea"],
+            label="agent",
+        )
+        kill_processes_on_port(constants.AGENT_HTTP_PORT, logger=self.logger)
         self._close_agent_log_file()
 
     def _get_tm_exit_url(self) -> str:
@@ -459,26 +524,12 @@ class BaseDeploymentRunner(AbstractDeploymentRunner, metaclass=ABCMeta):
         except Exception:  # pylint: disable=broad-except
             self.logger.exception("Exception on tendermint stop!")
 
-        pid_file = self._work_directory / "tendermint.pid"
-        if pid_file.exists():
-            try:
-                # Read and validate PID (checks process exists, removes stale files)
-                # Expected process names: tendermint, flask, python
-                pid = read_pid_file(
-                    pid_file,
-                    expected_process_names=["tendermint", "flask", "python"],
-                    remove_stale=True,
-                )
-                kill_process(pid)
-                # Clean up PID file after successful kill
-                remove_pid_file(pid_file, force=True)
-            except (FileNotFoundError, StalePIDFile):
-                # PID file doesn't exist or process already dead - OK
-                self.logger.debug(f"Tendermint PID file {pid_file} not found or stale")
-            except PIDFileError as e:
-                self.logger.error(f"Error reading tendermint PID file {pid_file}: {e}")
-                # Try to clean up invalid PID file
-                remove_pid_file(pid_file, force=True)
+        self._terminate_recorded_process(
+            self._work_directory / "tendermint.pid",
+            expected_process_names=["tendermint", "flask", "python"],
+            label="tendermint",
+        )
+        kill_processes_on_port(constants.TENDERMINT_COM_PORT, logger=self.logger)
         self._close_tm_log_file()
 
     @abstractmethod
@@ -860,7 +911,7 @@ class HostPythonHostDeploymentRunner(BaseDeploymentRunner):
                 "--host",
                 "localhost",
                 "--port",
-                "8080",
+                str(constants.TENDERMINT_COM_PORT),
             ],
             cwd=working_dir,
             stdout=self._tm_log_file,

--- a/operate/utils/pid_file.py
+++ b/operate/utils/pid_file.py
@@ -248,6 +248,26 @@ def read_pid_file(
     )
 
 
+def read_raw_pid(pid_file: Path) -> Optional[int]:
+    """Read the PID from a PID file without validation, locking, or removal.
+
+    Lets shutdown terminate a recorded process even when :func:`read_pid_file`
+    would classify it stale (and remove the file). Best-effort: a missing file
+    or torn read yields ``None`` rather than raising.
+
+    :param pid_file: Path to PID file
+    :return: PID if the file contains a valid integer, otherwise None
+    """
+    try:
+        content = pid_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return int(content)
+    except ValueError:
+        return None
+
+
 def remove_pid_file(pid_file: Path, force: bool = False) -> None:
     """Remove PID file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-middleware"
-version = "0.15.25"
+version = "0.15.26"
 description = ""
 license = "Apache-2.0"
 authors = [

--- a/tests/test_deployment_runner_unit2.py
+++ b/tests/test_deployment_runner_unit2.py
@@ -24,12 +24,14 @@ import os
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import psutil
 import pytest
 
+from operate import constants
 from operate.services.agent_assets import AgentAssetManager
 from operate.services.deployment_runner import (
     BaseDeploymentRunner,
@@ -39,6 +41,7 @@ from operate.services.deployment_runner import (
     PyInstallerHostDeploymentRunnerMac,
     _kill_process,
     kill_process,
+    kill_processes_on_port,
 )
 from operate.utils.pid_file import PIDFileError, StalePIDFile
 
@@ -620,11 +623,124 @@ class TestStart:
         runner = ConcreteDeploymentRunner(tmp_path, is_aea=False)
         with (
             patch.object(runner, "_setup_agent"),
+            patch.object(runner, "_free_deployment_ports"),
             patch.object(runner, "_start_tendermint") as mock_tm,
             patch.object(runner, "_start_agent"),
         ):
             runner._start(password="testpass")  # nosec B106
         mock_tm.assert_not_called()
+
+    def test_internal_start_frees_ports_before_launch(self, tmp_path: Path) -> None:
+        """_start reaps leftover port holders before starting tendermint/agent.
+
+        This is the pre-flight that breaks the agent-not-starting deadlock: a
+        leftover process holding the fixed port would otherwise make the new
+        agent fail to bind (OSError 10048).
+        """
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+        with (
+            patch.object(runner, "_setup_agent"),
+            patch.object(runner, "_free_deployment_ports") as mock_free,
+            patch.object(runner, "_start_tendermint"),
+            patch.object(runner, "_start_agent"),
+        ):
+            runner._start(password="testpass")  # nosec B106
+        mock_free.assert_called_once()
+
+    def test_free_deployment_ports_reaps_both_ports_for_aea(
+        self, tmp_path: Path
+    ) -> None:
+        """_free_deployment_ports reaps the agent and tendermint ports for aea."""
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+        with patch(
+            "operate.services.deployment_runner.kill_processes_on_port"
+        ) as mock_reap:
+            runner._free_deployment_ports()
+        reaped = {call.args[0] for call in mock_reap.call_args_list}
+        assert reaped == {constants.AGENT_HTTP_PORT, constants.TENDERMINT_COM_PORT}
+
+    def test_free_deployment_ports_skips_tendermint_when_not_aea(
+        self, tmp_path: Path
+    ) -> None:
+        """_free_deployment_ports only reaps the agent port when not aea."""
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=False)
+        with patch(
+            "operate.services.deployment_runner.kill_processes_on_port"
+        ) as mock_reap:
+            runner._free_deployment_ports()
+        reaped = {call.args[0] for call in mock_reap.call_args_list}
+        assert reaped == {constants.AGENT_HTTP_PORT}
+
+
+class TestKillProcessesOnPort:
+    """Tests for kill_processes_on_port (port-reap backstop, fix #2)."""
+
+    @staticmethod
+    def _conn(port: int, pid: int, status: str = psutil.CONN_LISTEN) -> Any:
+        return SimpleNamespace(
+            laddr=SimpleNamespace(ip="127.0.0.1", port=port),
+            status=status,
+            pid=pid,
+        )
+
+    def test_kills_listener_on_matching_port(self) -> None:
+        """A process listening on the target port is killed."""
+        logger = MagicMock()
+        with (
+            patch(
+                "operate.services.deployment_runner.psutil.net_connections",
+                return_value=[self._conn(8716, 4321)],
+            ),
+            patch("operate.services.deployment_runner.os.getpid", return_value=999),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+        ):
+            kill_processes_on_port(8716, logger=logger)
+        mock_kill.assert_called_once_with(4321)
+
+    def test_ignores_other_ports_and_non_listening(self) -> None:
+        """Connections on other ports or not in LISTEN state are ignored."""
+        logger = MagicMock()
+        conns = [
+            self._conn(9999, 1),
+            self._conn(8716, 2, status=psutil.CONN_ESTABLISHED),
+        ]
+        with (
+            patch(
+                "operate.services.deployment_runner.psutil.net_connections",
+                return_value=conns,
+            ),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+        ):
+            kill_processes_on_port(8716, logger=logger)
+        mock_kill.assert_not_called()
+
+    def test_skips_own_pid(self) -> None:
+        """The middleware never kills itself even if it matched the port."""
+        logger = MagicMock()
+        with (
+            patch(
+                "operate.services.deployment_runner.psutil.net_connections",
+                return_value=[self._conn(8716, 777)],
+            ),
+            patch("operate.services.deployment_runner.os.getpid", return_value=777),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+        ):
+            kill_processes_on_port(8716, logger=logger)
+        mock_kill.assert_not_called()
+
+    def test_access_denied_is_handled_gracefully(self) -> None:
+        """An AccessDenied while enumerating connections is logged, not raised."""
+        logger = MagicMock()
+        with (
+            patch(
+                "operate.services.deployment_runner.psutil.net_connections",
+                side_effect=psutil.AccessDenied(),
+            ),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+        ):
+            kill_processes_on_port(8716, logger=logger)
+        mock_kill.assert_not_called()
+        logger.warning.assert_called()
 
 
 # ---------------------------------------------------------------------------
@@ -729,27 +845,62 @@ class TestStopAgent:
 
         mock_kill.assert_called_once_with(12345)
 
-    def test_file_not_found_error_logged(self, tmp_path: Path) -> None:
-        """_stop_agent logs debug when FileNotFoundError raised."""
+    def test_file_not_found_with_dead_pid_skips_kill_and_cleans_up(
+        self, tmp_path: Path
+    ) -> None:
+        """_stop_agent skips the kill but removes the file when the PID is gone."""
         pid_file = tmp_path / "agent.pid"
         pid_file.write_text("12345", encoding="utf-8")
         runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
-        runner.logger = MagicMock()
 
         with (
             patch(
                 "operate.services.deployment_runner.read_pid_file",
                 side_effect=FileNotFoundError("not found"),
             ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=False,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
             patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file") as mock_remove,
         ):
             runner._stop_agent()
 
         mock_kill.assert_not_called()
-        runner.logger.debug.assert_called()
+        mock_remove.assert_called_once_with(pid_file, force=True)
 
-    def test_stale_pid_file_logged(self, tmp_path: Path) -> None:
-        """_stop_agent logs debug when StalePIDFile raised."""
+    def test_stale_pid_with_dead_process_skips_kill(self, tmp_path: Path) -> None:
+        """_stop_agent does not kill when the stale PID's process is dead."""
+        pid_file = tmp_path / "agent.pid"
+        pid_file.write_text("12345", encoding="utf-8")
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+
+        with (
+            patch(
+                "operate.services.deployment_runner.read_pid_file",
+                side_effect=StalePIDFile("stale"),
+            ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=False,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file"),
+        ):
+            runner._stop_agent()
+
+        mock_kill.assert_not_called()
+
+    def test_stale_pid_with_live_process_is_killed(self, tmp_path: Path) -> None:
+        """_stop_agent still kills a live process flagged stale (e.g. name mismatch).
+
+        Regression for the agent-not-starting deadlock: a live agent whose
+        process name did not match the expected list was previously abandoned,
+        leaving it holding the fixed port and blocking the next start.
+        """
         pid_file = tmp_path / "agent.pid"
         pid_file.write_text("12345", encoding="utf-8")
         runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
@@ -758,14 +909,29 @@ class TestStopAgent:
         with (
             patch(
                 "operate.services.deployment_runner.read_pid_file",
-                side_effect=StalePIDFile("stale"),
+                side_effect=StalePIDFile("name mismatch"),
             ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=True,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
             patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file"),
         ):
             runner._stop_agent()
 
-        mock_kill.assert_not_called()
-        runner.logger.debug.assert_called()
+        mock_kill.assert_called_once_with(12345)
+        runner.logger.warning.assert_called()
+
+    def test_stop_agent_reaps_fixed_port(self, tmp_path: Path) -> None:
+        """_stop_agent reaps the fixed agent HTTP port as a backstop."""
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+        with patch(
+            "operate.services.deployment_runner.kill_processes_on_port"
+        ) as mock_reap:
+            runner._stop_agent()
+        mock_reap.assert_any_call(constants.AGENT_HTTP_PORT, logger=runner.logger)
 
     def test_pid_file_error_logged_and_file_removed(self, tmp_path: Path) -> None:
         """_stop_agent logs error and calls remove_pid_file when PIDFileError raised."""
@@ -865,8 +1031,8 @@ class TestStopTendermint:
 
         mock_kill.assert_called_once_with(55555)
 
-    def test_stale_pid_file_logged(self, tmp_path: Path) -> None:
-        """_stop_tendermint logs debug on StalePIDFile."""
+    def test_stale_pid_with_live_process_is_killed(self, tmp_path: Path) -> None:
+        """_stop_tendermint still kills a live process flagged stale."""
         pid_file = tmp_path / "tendermint.pid"
         pid_file.write_text("55555", encoding="utf-8")
         runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
@@ -879,10 +1045,17 @@ class TestStopTendermint:
                 "operate.services.deployment_runner.read_pid_file",
                 side_effect=StalePIDFile("stale"),
             ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=True,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file"),
         ):
             runner._stop_tendermint()
 
-        runner.logger.debug.assert_called()
+        mock_kill.assert_called_once_with(55555)
 
     def test_pid_file_error_logs_and_removes(self, tmp_path: Path) -> None:
         """_stop_tendermint logs error and removes file on PIDFileError."""
@@ -905,12 +1078,11 @@ class TestStopTendermint:
         runner.logger.error.assert_called()
         mock_remove.assert_called_once_with(pid_file, force=True)
 
-    def test_file_not_found_error_logged(self, tmp_path: Path) -> None:
-        """_stop_tendermint logs debug when FileNotFoundError raised."""
+    def test_file_not_found_with_dead_pid_skips_kill(self, tmp_path: Path) -> None:
+        """_stop_tendermint skips the kill when the file is gone and PID is dead."""
         pid_file = tmp_path / "tendermint.pid"
         pid_file.write_text("55555", encoding="utf-8")
         runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
-        runner.logger = MagicMock()
 
         with (
             patch("operate.services.deployment_runner.requests.get"),
@@ -919,10 +1091,30 @@ class TestStopTendermint:
                 "operate.services.deployment_runner.read_pid_file",
                 side_effect=FileNotFoundError("gone"),
             ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=False,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file"),
         ):
             runner._stop_tendermint()
 
-        runner.logger.debug.assert_called()
+        mock_kill.assert_not_called()
+
+    def test_stop_tendermint_reaps_fixed_port(self, tmp_path: Path) -> None:
+        """_stop_tendermint reaps the fixed tendermint control port as a backstop."""
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+        with (
+            patch("operate.services.deployment_runner.requests.get"),
+            patch("operate.services.deployment_runner.time.sleep"),
+            patch(
+                "operate.services.deployment_runner.kill_processes_on_port"
+            ) as mock_reap,
+        ):
+            runner._stop_tendermint()
+        mock_reap.assert_any_call(constants.TENDERMINT_COM_PORT, logger=runner.logger)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deployment_runner_unit2.py
+++ b/tests/test_deployment_runner_unit2.py
@@ -728,13 +728,14 @@ class TestKillProcessesOnPort:
             kill_processes_on_port(8716, logger=logger)
         mock_kill.assert_not_called()
 
-    def test_access_denied_is_handled_gracefully(self) -> None:
-        """An AccessDenied while enumerating connections is logged, not raised."""
+    @pytest.mark.parametrize("exc", [psutil.AccessDenied(), OSError("eperm")])
+    def test_enumeration_failure_is_handled_gracefully(self, exc: Exception) -> None:
+        """A connection-enumeration error is logged, not raised."""
         logger = MagicMock()
         with (
             patch(
                 "operate.services.deployment_runner.psutil.net_connections",
-                side_effect=psutil.AccessDenied(),
+                side_effect=exc,
             ),
             patch("operate.services.deployment_runner.kill_process") as mock_kill,
         ):

--- a/tests/test_deployment_runner_unit2.py
+++ b/tests/test_deployment_runner_unit2.py
@@ -952,6 +952,30 @@ class TestStopAgent:
         runner.logger.error.assert_called()
         mock_remove.assert_called_once_with(pid_file, force=True)
 
+    def test_pid_file_error_with_live_process_is_killed(self, tmp_path: Path) -> None:
+        """_stop_agent kills the recorded PID on PIDFileError when it is alive."""
+        pid_file = tmp_path / "agent.pid"
+        pid_file.write_text("12345", encoding="utf-8")
+        runner = ConcreteDeploymentRunner(tmp_path, is_aea=True)
+        runner.logger = MagicMock()
+
+        with (
+            patch(
+                "operate.services.deployment_runner.read_pid_file",
+                side_effect=PIDFileError("bad pid"),
+            ),
+            patch(
+                "operate.services.deployment_runner.psutil.pid_exists",
+                return_value=True,
+            ),
+            patch("operate.services.deployment_runner.kill_processes_on_port"),
+            patch("operate.services.deployment_runner.kill_process") as mock_kill,
+            patch("operate.services.deployment_runner.remove_pid_file"),
+        ):
+            runner._stop_agent()
+
+        mock_kill.assert_called_once_with(12345)
+
 
 # ---------------------------------------------------------------------------
 # _get_tm_exit_url test

--- a/tests/test_pid_file.py
+++ b/tests/test_pid_file.py
@@ -21,6 +21,7 @@ from operate.utils.pid_file import (
     _acquire_lock,
     _release_lock,
     read_pid_file,
+    read_raw_pid,
     remove_pid_file,
     validate_pid,
     write_pid_file,
@@ -550,3 +551,23 @@ class TestRemovePIDFileEdgeCases:
         mock_logger.error.assert_called()
         error_msg = str(mock_logger.error.call_args)
         assert "Failed to remove PID file" in error_msg
+
+
+class TestReadRawPid:
+    """Tests for read_raw_pid."""
+
+    def test_returns_pid_for_valid_content(self, tmp_path: Path) -> None:
+        """Returns the integer PID when the file holds a valid integer."""
+        pid_file = tmp_path / "x.pid"
+        pid_file.write_text("4321", encoding="utf-8")
+        assert read_raw_pid(pid_file) == 4321
+
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        """Returns None (not raises) when the file cannot be read."""
+        assert read_raw_pid(tmp_path / "missing.pid") is None
+
+    def test_returns_none_for_non_integer_content(self, tmp_path: Path) -> None:
+        """Returns None when the file content is not an integer."""
+        pid_file = tmp_path / "x.pid"
+        pid_file.write_text("not-a-pid", encoding="utf-8")
+        assert read_raw_pid(pid_file) is None

--- a/uv.lock
+++ b/uv.lock
@@ -2022,7 +2022,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.25"
+version = "0.15.26"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Trader agents got stuck **not starting**, surviving reboots. Investigation of a Windows debug bundle showed one service restarting every ~5.5 min indefinitely. Each restart's agent log ended with:

```
OSError: [Errno 10048] error while attempting to bind on address ('127.0.0.1', 8716): only one usage of each socket address ...
aea.mail.base.AEAConnectionError: Failed to connect the multiplexer.
```

### Root cause — a self-sustaining deadlock

Every agent binds **fixed local ports** (`8716` HTTP server, `8080` tendermint control), so only one agent can run at a time. The loop:

1. An agent goes unhealthy (HTTP `425`) but keeps its HTTP server bound to `8716`.
2. The health checker restarts it; `_stop_agent` reads the PID, `validate_pid` flags it **stale** (process-name mismatch / PID reuse on Windows), and the old code **silently skipped `kill_process`** (`Removing stale PID file …`).
3. The process keeps holding `8716`; the new agent can't bind → `OSError 10048` → multiplexer fails → it dies.
4. The old process still answers `425` → back to step 2, forever.

A reboot clears the orphan, but the service auto-resumes and re-enters the same loop within minutes — hence "still not working after reboot".

## Fix

- **Stop actually kills the process.** `_terminate_recorded_process` now kills the recorded PID on the stale path when it is still alive, instead of skipping it.
- **Free the fixed ports as a backstop.** `kill_processes_on_port` reaps any process listening on the fixed ports — before start (pre-flight) and after stop — covering PID-tracking misses (orphaned child, PID reuse, unexpected process name). `net_connections` needs root on macOS and is skipped there, where the PID-based kill applies instead.
- **Single source of truth** for the ports via new `AGENT_HTTP_PORT` / `TENDERMINT_COM_PORT` constants.

## Tests

`tests/test_deployment_runner_unit2.py`: updated the stop tests to the new behavior and added coverage for the stale-but-live kill (the regression), port-free pre-flight in `_start`, `_free_deployment_ports`, and `kill_processes_on_port` (matching listener killed, other ports/non-listening ignored, own PID skipped, `AccessDenied` handled).

## Validation

`unit-tests`, `flake8`, `pylint` (10.00/10), `black-check`, `isort-check`, `bandit`, `safety`, `mypy` — all pass.

## Notes

This fixes the reboot-proof restart **deadlock**. The original trigger (why the agent first stalls at HTTP `425`) is environment-specific and best captured on a clean single-service run; these changes ensure a restart can no longer wedge itself on the port once that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)