### PR TITLE
fix: fail fast with INSUFFICIENT_SIGNER_GAS when signer cannot cover gas (OPE-1770)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/advise-code-review.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/advise-code-review.py\"",
             "timeout": 10,
             "statusMessage": "Reminding about pre-commit code review"
           }

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,6 +210,8 @@ Update account password.
 
 Validate user credentials and establish a session.
 
+A successful login also starts two background jobs: the recurring funding job, and a one-shot service maintenance task. Maintenance failures never affect the login response; they are logged and retried at the next login.
+
 **Request Body:**
 
 ```json

--- a/operate/bridge/providers/provider.py
+++ b/operate/bridge/providers/provider.py
@@ -434,7 +434,10 @@ class Provider(ABC):
             for tx_label, tx in txs:
                 self.logger.info(f"[PROVIDER] Executing transaction {tx_label}.")
                 with wrap_gas_spike_as_insufficient_funds(
-                    chain.value, f"bridge transaction {tx_label}"
+                    chain.value,
+                    f"bridge transaction {tx_label}",
+                    ledger_api=from_ledger_api,
+                    signer_address=wallet.crypto.address,
                 ):
                     tx_settler = TxSettler(
                         ledger_api=from_ledger_api,

--- a/operate/cli.py
+++ b/operate/cli.py
@@ -507,6 +507,7 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
     operate = OperateApp(home=home)
 
     funding_job: t.Optional[asyncio.Task] = None
+    maintenance_task: t.Optional[asyncio.Task] = None
     health_checker = HealthChecker(
         operate.service_manager(), number_of_fails=number_of_fails, logger=logger
     )
@@ -559,6 +560,16 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             funding_job = None  # pragma: no cover
         else:
             logger.info("Funding job cancellation failed")
+
+    def post_login_schedule() -> None:
+        """Schedule that runs right after login."""
+        # service_maintenance never raises; failures are logged inside.
+        # Keep a reference to the task: the event loop only holds weak
+        # references, so a fire-and-forget task may be garbage collected.
+        nonlocal maintenance_task
+        maintenance_task = asyncio.get_running_loop().create_task(
+            run_in_executor(operate.service_manager().service_maintenance)
+        )
 
     def pause_all_services_on_startup() -> None:
         logger.info("Stopping services on startup...")
@@ -838,6 +849,7 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
 
         operate.password = data["password"]
         schedule_funding_job()
+        post_login_schedule()
         return JSONResponse(
             content={"message": "Login successful."},
             status_code=HTTPStatus.OK,

--- a/operate/services/funding_manager.py
+++ b/operate/services/funding_manager.py
@@ -111,6 +111,16 @@ class FundingManager:  # pylint: disable=too-many-instance-attributes
         self._funding_requests_cooldown_until: t.Dict[str, float] = {}
         self.is_for_quickstart = False
 
+    def get_withdrawal_lock(
+        self, service_config_id: str, chain: Chain
+    ) -> threading.Lock:
+        """Return the per-(service, chain) lock guarding service-safe withdrawals."""
+        lock_key = (service_config_id, chain.value)
+        with self._withdrawal_locks_mu:
+            if lock_key not in self._withdrawal_locks:
+                self._withdrawal_locks[lock_key] = threading.Lock()
+            return self._withdrawal_locks[lock_key]
+
     def drain_agents_eoas(
         self, service: Service, withdrawal_address: str, chain: Chain
     ) -> None:
@@ -450,11 +460,9 @@ class FundingManager:  # pylint: disable=too-many-instance-attributes
         # Per-(service, chain) lock prevents TOCTOU races from concurrent
         # withdrawal requests on the same service safe without blocking
         # unrelated funding operations or withdrawals on other services/chains.
-        lock_key = (service_config_id, chain.value)
-        with self._withdrawal_locks_mu:
-            if lock_key not in self._withdrawal_locks:
-                self._withdrawal_locks[lock_key] = threading.Lock()
-            withdrawal_lock = self._withdrawal_locks[lock_key]
+        withdrawal_lock = self.get_withdrawal_lock(
+            service_config_id=service_config_id, chain=chain
+        )
 
         with withdrawal_lock:
             # Re-validate against live balances (Safe gas is paid by signer EOA)

--- a/operate/services/manage.py
+++ b/operate/services/manage.py
@@ -22,6 +22,7 @@
 import json
 import logging
 import os
+import threading
 import traceback
 import typing as t
 from collections import Counter, defaultdict
@@ -68,6 +69,7 @@ from operate.ledger.profiles import (
 from operate.operate_types import (
     Chain,
     ChainAmounts,
+    DeploymentStatus,
     FundingValues,
     LedgerConfig,
     MechMarketplaceConfig,
@@ -134,6 +136,7 @@ class ServiceManager:
         self.funding_manager = funding_manager
         self.logger = logger
         self.skip_depencency_check = skip_dependency_check
+        self._maintenance_lock = threading.Lock()
 
     def setup(self) -> None:
         """Setup service manager."""
@@ -2285,6 +2288,90 @@ class ServiceManager:
             withdrawal_address=withdrawal_address,
             chain=chain,
         )
+
+    def service_maintenance(self) -> t.Dict[str, t.List[str]]:
+        """Maintenance of the service to sync it with on-chain data"""
+        result: t.Dict[str, t.List[str]] = {
+            "processed": [],
+            "skipped": [],
+            "failed": [],
+        }
+        if not self._maintenance_lock.acquire(  # pylint: disable=consider-using-with
+            blocking=False
+        ):
+            self.logger.info("[Maintenance] Maintenance already in progress; skipping.")
+            return result
+        try:  # pylint: disable=too-many-nested-blocks
+            services, _ = self.get_all_services()
+            for service in services:
+                if service.deployment.status in (
+                    DeploymentStatus.DEPLOYING,
+                    DeploymentStatus.DEPLOYED,
+                    DeploymentStatus.STOPPING,
+                ):
+                    # A locally running/transitioning deployment must not race
+                    # with maintenance transfers.
+                    continue
+                for chain_str, chain_config in service.chain_configs.items():
+                    tag = f"{service.service_config_id}:{chain_str}"
+                    try:
+                        chain_data = chain_config.chain_data
+                        if chain_data.token == NON_EXISTENT_TOKEN:
+                            continue
+                        multisig = chain_data.multisig
+                        if not multisig or multisig in (
+                            NON_EXISTENT_MULTISIG,
+                            ZERO_ADDRESS,
+                        ):
+                            continue
+                        chain = Chain(chain_str)
+                        wallet = self.wallet_manager.load(chain.ledger_type)
+                        if chain not in wallet.safes:
+                            result["skipped"].append(tag)
+                            continue
+                        master_safe = wallet.safes[chain]
+                        # Hold the same per-(service, chain) lock as user
+                        # withdrawals, and read the on-chain state under it,
+                        # right before transferring.
+                        withdrawal_lock = self.funding_manager.get_withdrawal_lock(
+                            service_config_id=service.service_config_id,
+                            chain=chain,
+                        )
+                        if not withdrawal_lock.acquire(blocking=False):
+                            result["skipped"].append(tag)
+                            continue
+                        try:
+                            state = self._get_on_chain_state(
+                                service=service, chain=chain_str
+                            )
+                            if state not in {
+                                OnChainState.PRE_REGISTRATION,
+                                OnChainState.ACTIVE_REGISTRATION,
+                            }:
+                                continue
+                            self.logger.info(
+                                f"[Maintenance] Maintaining service {multisig} -> "
+                                f"{master_safe} ({tag}, state={state.name})."
+                            )
+                            self.drain(
+                                service_config_id=service.service_config_id,
+                                chain_str=chain_str,
+                                withdrawal_address=master_safe,
+                            )
+                            result["processed"].append(tag)
+                        finally:
+                            withdrawal_lock.release()
+                    except Exception as e:  # pylint: disable=broad-except
+                        # Expected on transient conditions (RPC offline,
+                        # gas-poor signer); warn without a traceback to keep
+                        # login-time logs readable.
+                        self.logger.warning(f"[Maintenance] Failed for {tag}: {e}")
+                        result["failed"].append(tag)
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error(f"[Maintenance] Aborted: {e}\n{traceback.format_exc()}")
+        finally:
+            self._maintenance_lock.release()
+        return result
 
     def deploy_service_locally(  # pylint: disable=too-many-arguments
         self,

--- a/operate/services/protocol.py
+++ b/operate/services/protocol.py
@@ -214,7 +214,10 @@ class GnosisSafeTransaction:
     def settle(self) -> TxReceipt:
         """Settle the transaction."""
         with wrap_gas_spike_as_insufficient_funds(
-            self.chain_type.value, "settle Safe transaction"
+            self.chain_type.value,
+            "settle Safe transaction",
+            ledger_api=self.ledger_api,
+            signer_address=self.crypto.address,
         ):
             return (
                 TxSettler(

--- a/operate/utils/gas.py
+++ b/operate/utils/gas.py
@@ -22,15 +22,80 @@
 import typing as t
 from contextlib import contextmanager
 
+from aea.crypto.base import LedgerApi
+from aea_ledger_ethereum import EIP1559, get_default_gas_strategy
 from autonomy.chain.exceptions import ChainInteractionError
 
 from operate.exceptions import InsufficientFundsException
 from operate.ledger import is_gas_spike_error
+from operate.operate_types import Chain
+
+# Assumed gas consumption of the cheapest realistic middleware transaction,
+# used as the pre-flight affordability floor (signer must hold at least
+# gas_price * MIN_GAS_UNITS). A plain transfer costs 21k gas, but the flows
+# guarded here are Safe execTransaction calls (~60-120k), ERC20 transfers
+# (~50-65k), Safe creation (~280k) and bridge txs (>100k). 100k is kept
+# deliberately low to avoid false positives: it only needs to catch
+# effectively-zero balances instantly; marginal balances still fail in
+# TxSettler and are translated via the gas-spike message path. No upstream
+# constant exists for this — aea-ledger-ethereum always estimates gas live
+# and defines price constants only.
+MIN_GAS_UNITS = 100_000
+
+
+def _fallback_gas_price(chain: str) -> int:
+    """Chain-aware fallback gas price, mirroring EthereumApi's own fallback estimate."""
+    strategy = get_default_gas_strategy(Chain(chain).id)
+    return strategy[EIP1559]["fallback_estimate"]["maxFeePerGas"]
+
+
+def _preflight_signer_gas(ledger_api: LedgerApi, address: str, chain: str) -> None:
+    """Raise InsufficientFundsException immediately if the signer EOA can't cover gas."""
+    try:
+        balance = ledger_api.get_balance(address)
+        if not isinstance(balance, int):
+            return
+        if balance >= _fallback_gas_price(chain) * MIN_GAS_UNITS:
+            # Comfortably funded under the chain's conservative fallback price;
+            # skip the gas-pricing RPC entirely.
+            return
+        # Gray zone: confirm against live pricing. Nodes validate balance
+        # against maxFeePerGas * gas_limit when accepting an EIP-1559 tx,
+        # so maxFeePerGas is the correct price to threshold on.
+        gas_pricing = ledger_api.try_get_gas_pricing()
+        if gas_pricing is not None:
+            gas_price = gas_pricing.get("maxFeePerGas") or gas_pricing.get("gasPrice")
+        else:
+            gas_price = None
+        if gas_price is None:
+            gas_price = _fallback_gas_price(chain)
+        threshold = gas_price * MIN_GAS_UNITS
+        if balance < threshold:
+            raise InsufficientFundsException(
+                f"Signer {address} has insufficient gas on {chain}: "
+                f"balance {balance} wei < required {threshold} wei.",
+                chain=chain,
+            )
+    except InsufficientFundsException:
+        raise
+    except Exception:  # pylint: disable=broad-except
+        return  # swallow RPC errors — let TxSettler handle them naturally
 
 
 @contextmanager
-def wrap_gas_spike_as_insufficient_funds(chain: str, action: str) -> t.Iterator[None]:
-    """Translate TxSettler gas-spike failures into InsufficientFundsException."""
+def wrap_gas_spike_as_insufficient_funds(
+    chain: str,
+    action: str,
+    ledger_api: LedgerApi,
+    signer_address: str,
+) -> t.Iterator[None]:
+    """Translate TxSettler gas-spike failures into InsufficientFundsException.
+
+    Performs a pre-flight gas check on *signer_address* before entering the
+    guarded block, raising InsufficientFundsException immediately when the
+    signer cannot cover gas for even a minimal transaction.
+    """
+    _preflight_signer_gas(ledger_api, signer_address, chain)
     try:
         yield
     except (ValueError, ChainInteractionError) as exc:

--- a/operate/utils/gas.py
+++ b/operate/utils/gas.py
@@ -64,7 +64,8 @@ def _preflight_signer_gas(ledger_api: LedgerApi, address: str, chain: str) -> No
         # so maxFeePerGas is the correct price to threshold on.
         gas_pricing = ledger_api.try_get_gas_pricing()
         if gas_pricing is not None:
-            gas_price = gas_pricing.get("maxFeePerGas") or gas_pricing.get("gasPrice")
+            max_fee = gas_pricing.get("maxFeePerGas")
+            gas_price = max_fee if max_fee is not None else gas_pricing.get("gasPrice")
         else:
             gas_price = None
         if gas_price is None:

--- a/operate/utils/gnosis.py
+++ b/operate/utils/gnosis.py
@@ -188,7 +188,9 @@ def create_safe(
         return tx
 
     chain = Chain.from_id(ledger_api._chain_id)  # pylint: disable=protected-access
-    with wrap_gas_spike_as_insufficient_funds(chain.value, "create Safe"):
+    with wrap_gas_spike_as_insufficient_funds(
+        chain.value, "create Safe", ledger_api=ledger_api, signer_address=crypto.address
+    ):
         tx_settler = (
             TxSettler(
                 ledger_api=ledger_api,
@@ -271,7 +273,12 @@ def send_safe_txs(
         )
 
     chain = Chain.from_id(ledger_api._chain_id)  # pylint: disable=protected-access
-    with wrap_gas_spike_as_insufficient_funds(chain.value, "send Safe transaction"):
+    with wrap_gas_spike_as_insufficient_funds(
+        chain.value,
+        "send Safe transaction",
+        ledger_api=ledger_api,
+        signer_address=crypto.address,
+    ):
         return (
             TxSettler(
                 ledger_api=ledger_api,
@@ -438,7 +445,12 @@ def transfer(
         )
 
     chain = Chain.from_id(ledger_api._chain_id)  # pylint: disable=protected-access
-    with wrap_gas_spike_as_insufficient_funds(chain.value, "transfer from Safe"):
+    with wrap_gas_spike_as_insufficient_funds(
+        chain.value,
+        "transfer from Safe",
+        ledger_api=ledger_api,
+        signer_address=crypto.address,
+    ):
         return (
             TxSettler(
                 ledger_api=ledger_api,
@@ -515,7 +527,12 @@ def transfer_erc20_from_eoa(
         return tx
 
     chain = Chain.from_id(ledger_api._chain_id)  # pylint: disable=protected-access
-    with wrap_gas_spike_as_insufficient_funds(chain.value, "transfer ERC20 from EOA"):
+    with wrap_gas_spike_as_insufficient_funds(
+        chain.value,
+        "transfer ERC20 from EOA",
+        ledger_api=ledger_api,
+        signer_address=crypto.address,
+    ):
         return (
             TxSettler(
                 ledger_api=ledger_api,

--- a/operate/wallet/master.py
+++ b/operate/wallet/master.py
@@ -464,7 +464,10 @@ class EthereumMasterWallet(
             )
 
         with wrap_gas_spike_as_insufficient_funds(
-            chain.value, f"transfer from EOA on {chain.name}"
+            chain.value,
+            f"transfer from EOA on {chain.name}",
+            ledger_api=ledger_api,
+            signer_address=self.crypto.address,
         ):
             return (
                 TxSettler(
@@ -555,7 +558,10 @@ class EthereumMasterWallet(
             return tx
 
         with wrap_gas_spike_as_insufficient_funds(
-            chain.value, f"transfer ERC20 from EOA on {chain.name}"
+            chain.value,
+            f"transfer ERC20 from EOA on {chain.name}",
+            ledger_api=ledger_api,
+            signer_address=self.crypto.address,
         ):
             return (
                 TxSettler(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-middleware"
-version = "0.15.27"
+version = "0.15.28"
 description = ""
 license = "Apache-2.0"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 requires-python = "<3.15,>=3.10"
 readme = "README.md"
 dependencies = [
-    "open-autonomy[cli,docker]>=0.21.21,<0.22",
+    "open-autonomy[cli,docker]>=0.21.24,<0.22",
     "open-aea-ledger-cosmos>=2.2.5,<3",
     "open-aea-ledger-ethereum>=2.2.5,<3",
     "open-aea-cli-ipfs>=2.2.5,<3",

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -25,6 +25,7 @@ import logging
 import multiprocessing
 import os
 import signal as signal_module
+import threading
 from contextlib import ExitStack
 from http import HTTPStatus
 from pathlib import Path
@@ -350,6 +351,29 @@ class TestCreateAppInfra:
                 )
             # schedule_funding_job is called on successful login
             assert resp.status_code in (HTTPStatus.OK, HTTPStatus.UNAUTHORIZED)
+
+    def test_login_schedules_service_maintenance(self) -> None:
+        """A successful login schedules the one-shot service maintenance task."""
+        m = _make_mock_operate()
+        ua = MagicMock()
+        ua.is_valid.return_value = True
+        m.user_account = ua
+        maintenance_called = threading.Event()
+        m.service_manager.return_value.service_maintenance.side_effect = (
+            lambda: maintenance_called.set()
+        )
+
+        stack, app, _, _ = _open_app(m)
+        with stack:
+            with TestClient(app, raise_server_exceptions=False) as client:
+                m.password = None  # not logged in before login
+                resp = client.post(
+                    "/api/account/login",
+                    json={"password": _TEST_PW_TESTPASS123},
+                )
+                assert resp.status_code == HTTPStatus.OK
+                # The task runs in the app's event loop / executor; wait for it.
+                assert maintenance_called.wait(timeout=5)
 
     # ── cancel_funding_job ────────────────────────────────────────────────────
 

--- a/tests/test_manage_unit.py
+++ b/tests/test_manage_unit.py
@@ -26,10 +26,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from operate.constants import ZERO_ADDRESS
+from operate.exceptions import InsufficientFundsException
 from operate.ledger.profiles import DEFAULT_EOA_TOPUPS
-from operate.operate_types import Chain, LedgerConfig
+from operate.operate_types import (
+    Chain,
+    DeploymentStatus,
+    LedgerConfig,
+    OnChainState,
+)
 from operate.services.manage import NUM_LOCAL_AGENT_INSTANCES, ServiceManager
 from operate.services.service import (
+    NON_EXISTENT_MULTISIG,
     NON_EXISTENT_TOKEN,
     SERVICE_CONFIG_PREFIX,
     SERVICE_CONFIG_VERSION,
@@ -1252,3 +1259,289 @@ class TestGetMasterEoaNativeFundingValues:
         assert result["topup"] == topup
         assert result["threshold"] == topup
         assert result["balance"] == 0
+
+
+def _make_maintenance_service(
+    token: int = 1,
+    multisig: t.Optional[str] = "0xAgentSafe",
+    chains: t.Optional[t.List[str]] = None,
+    status: DeploymentStatus = DeploymentStatus.STOPPED,
+) -> MagicMock:
+    """Create a mock service suitable for service_maintenance tests."""
+    service = _make_mock_service()
+    service.deployment.status = status
+    service.chain_configs = {}
+    for chain_str in chains or [_CHAIN]:
+        chain_config = MagicMock()
+        chain_config.chain_data.token = token
+        chain_config.chain_data.multisig = multisig
+        chain_config.ledger_config.rpc = _RPC
+        service.chain_configs[chain_str] = chain_config
+    return service
+
+
+class TestServiceMaintenance:
+    """Tests for ServiceManager.service_maintenance()."""
+
+    def _run(
+        self,
+        tmp_path: Path,
+        services: t.List[MagicMock],
+        state: OnChainState = OnChainState.PRE_REGISTRATION,
+        master_safes: t.Optional[t.Dict[Chain, str]] = None,
+    ) -> t.Tuple[ServiceManager, t.Dict[str, t.List[str]], MagicMock]:
+        """Run service_maintenance with mocked collaborators; returns (manager, result, drain)."""
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = (
+            master_safes if master_safes is not None else {Chain.GNOSIS: "0xMasterSafe"}
+        )
+        manager.wallet_manager.load.return_value = wallet
+        with (
+            patch.object(manager, "get_all_services", return_value=(services, True)),
+            patch.object(
+                manager, "_get_on_chain_state", return_value=state
+            ) as state_mock,
+            patch.object(manager, "drain") as drain_mock,
+        ):
+            result = manager.service_maintenance()
+        self._last_state_mock = state_mock
+        return manager, result, drain_mock
+
+    def test_processes_pre_registration_service(self, tmp_path: Path) -> None:
+        """A PreRegistration service is drained to the master safe."""
+        service = _make_maintenance_service()
+        _, result, drain = self._run(tmp_path, [service])
+        drain.assert_called_once_with(
+            service_config_id=service.service_config_id,
+            chain_str=_CHAIN,
+            withdrawal_address="0xMasterSafe",
+        )
+        assert result["processed"] == [f"{service.service_config_id}:{_CHAIN}"]
+        assert result["failed"] == []
+
+    def test_processes_active_registration_service(self, tmp_path: Path) -> None:
+        """An ActiveRegistration service is drained."""
+        service = _make_maintenance_service()
+        _, result, drain = self._run(
+            tmp_path, [service], state=OnChainState.ACTIVE_REGISTRATION
+        )
+        drain.assert_called_once()
+        assert result["processed"] == [f"{service.service_config_id}:{_CHAIN}"]
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            OnChainState.NON_EXISTENT,
+            OnChainState.FINISHED_REGISTRATION,
+            OnChainState.DEPLOYED,
+            OnChainState.TERMINATED_BONDED,
+            OnChainState.UNBONDED,
+        ],
+    )
+    def test_state_gate_blocks_other_states(
+        self, tmp_path: Path, state: OnChainState
+    ) -> None:
+        """Services in other on-chain states are not drained."""
+        _, result, drain = self._run(
+            tmp_path, [_make_maintenance_service()], state=state
+        )
+        drain.assert_not_called()
+        assert result == {"processed": [], "skipped": [], "failed": []}
+
+    @pytest.mark.parametrize("multisig", [NON_EXISTENT_MULTISIG, ZERO_ADDRESS, ""])
+    def test_multisig_gate(self, tmp_path: Path, multisig: t.Optional[str]) -> None:
+        """Services without an agent safe are skipped before any on-chain query."""
+        service = _make_maintenance_service(multisig=multisig)
+        _, result, drain = self._run(tmp_path, [service])
+        drain.assert_not_called()
+        self._last_state_mock.assert_not_called()
+        assert result == {"processed": [], "skipped": [], "failed": []}
+
+    def test_token_gate(self, tmp_path: Path) -> None:
+        """Services never minted on a chain are skipped without on-chain queries."""
+        service = _make_maintenance_service(token=NON_EXISTENT_TOKEN)
+        _, result, drain = self._run(tmp_path, [service])
+        drain.assert_not_called()
+        self._last_state_mock.assert_not_called()
+
+    def test_missing_master_safe_is_skipped(self, tmp_path: Path) -> None:
+        """Chains without a master safe are reported as skipped."""
+        service = _make_maintenance_service()
+        _, result, drain = self._run(tmp_path, [service], master_safes={})
+        drain.assert_not_called()
+        assert result["skipped"] == [f"{service.service_config_id}:{_CHAIN}"]
+
+    def test_per_chain_error_is_isolated(self, tmp_path: Path) -> None:
+        """A failure on one service does not prevent draining the next one."""
+        failing = _make_maintenance_service()
+        failing.service_config_id = "sc-failing"
+        healthy = _make_maintenance_service()
+        healthy.service_config_id = "sc-healthy"
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = {Chain.GNOSIS: "0xMasterSafe"}
+        manager.wallet_manager.load.return_value = wallet
+        with (
+            patch.object(
+                manager, "get_all_services", return_value=([failing, healthy], True)
+            ),
+            patch.object(
+                manager,
+                "_get_on_chain_state",
+                side_effect=[RuntimeError("RPC down"), OnChainState.PRE_REGISTRATION],
+            ),
+            patch.object(manager, "drain") as drain_mock,
+        ):
+            result = manager.service_maintenance()
+        drain_mock.assert_called_once()
+        assert result["failed"] == [f"sc-failing:{_CHAIN}"]
+        assert result["processed"] == [f"sc-healthy:{_CHAIN}"]
+
+    def test_drain_insufficient_funds_is_isolated(self, tmp_path: Path) -> None:
+        """An InsufficientFundsException from drain is logged, not raised."""
+        service = _make_maintenance_service()
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = {Chain.GNOSIS: "0xMasterSafe"}
+        manager.wallet_manager.load.return_value = wallet
+        with (
+            patch.object(manager, "get_all_services", return_value=([service], True)),
+            patch.object(
+                manager,
+                "_get_on_chain_state",
+                return_value=OnChainState.PRE_REGISTRATION,
+            ),
+            patch.object(
+                manager,
+                "drain",
+                side_effect=InsufficientFundsException("no gas", chain=_CHAIN),
+            ),
+        ):
+            result = manager.service_maintenance()
+        assert result["failed"] == [f"{service.service_config_id}:{_CHAIN}"]
+        assert result["processed"] == []
+
+    def test_lock_held_returns_immediately(self, tmp_path: Path) -> None:
+        """An in-progress maintenance run makes a concurrent call a no-op."""
+        manager = _make_manager(tmp_path)
+        with patch.object(manager, "get_all_services") as get_all_mock:
+            manager._maintenance_lock.acquire()  # pylint: disable=consider-using-with
+            try:
+                result = manager.service_maintenance()
+            finally:
+                manager._maintenance_lock.release()
+        get_all_mock.assert_not_called()
+        assert result == {"processed": [], "skipped": [], "failed": []}
+
+    def test_enumeration_error_is_swallowed(self, tmp_path: Path) -> None:
+        """An error while enumerating services aborts quietly without raising."""
+        manager = _make_manager(tmp_path)
+        with patch.object(
+            manager, "get_all_services", side_effect=RuntimeError("disk error")
+        ):
+            result = manager.service_maintenance()
+        assert result == {"processed": [], "skipped": [], "failed": []}
+        assert not manager._maintenance_lock.locked()
+
+    def test_multi_chain_only_passing_chain_drained(self, tmp_path: Path) -> None:
+        """Only the chain meeting all gates is drained on a multi-chain service."""
+        service = _make_maintenance_service(chains=["gnosis", "base"])
+        service.chain_configs["base"].chain_data.token = NON_EXISTENT_TOKEN
+        _, result, drain = self._run(tmp_path, [service])
+        drain.assert_called_once_with(
+            service_config_id=service.service_config_id,
+            chain_str="gnosis",
+            withdrawal_address="0xMasterSafe",
+        )
+        assert result["processed"] == [f"{service.service_config_id}:gnosis"]
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            DeploymentStatus.DEPLOYING,
+            DeploymentStatus.DEPLOYED,
+            DeploymentStatus.STOPPING,
+        ],
+    )
+    def test_locally_active_deployment_skipped(
+        self, tmp_path: Path, status: DeploymentStatus
+    ) -> None:
+        """Locally running/transitioning deployments are never drained."""
+        service = _make_maintenance_service(status=status)
+        _, result, drain = self._run(tmp_path, [service])
+        drain.assert_not_called()
+        self._last_state_mock.assert_not_called()
+        assert result == {"processed": [], "skipped": [], "failed": []}
+
+    def test_busy_withdrawal_lock_is_skipped(self, tmp_path: Path) -> None:
+        """A held per-(service, chain) withdrawal lock skips the service chain."""
+        service = _make_maintenance_service()
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = {Chain.GNOSIS: "0xMasterSafe"}
+        manager.wallet_manager.load.return_value = wallet
+        busy_lock = MagicMock()
+        busy_lock.acquire.return_value = False
+        manager.funding_manager.get_withdrawal_lock.return_value = busy_lock
+        with (
+            patch.object(manager, "get_all_services", return_value=([service], True)),
+            patch.object(manager, "_get_on_chain_state") as state_mock,
+            patch.object(manager, "drain") as drain_mock,
+        ):
+            result = manager.service_maintenance()
+        drain_mock.assert_not_called()
+        state_mock.assert_not_called()
+        busy_lock.release.assert_not_called()
+        assert result["skipped"] == [f"{service.service_config_id}:{_CHAIN}"]
+
+    def test_withdrawal_lock_released_after_drain(self, tmp_path: Path) -> None:
+        """The withdrawal lock is acquired before the state check and released after."""
+        service = _make_maintenance_service()
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = {Chain.GNOSIS: "0xMasterSafe"}
+        manager.wallet_manager.load.return_value = wallet
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        manager.funding_manager.get_withdrawal_lock.return_value = lock
+        with (
+            patch.object(manager, "get_all_services", return_value=([service], True)),
+            patch.object(
+                manager,
+                "_get_on_chain_state",
+                return_value=OnChainState.PRE_REGISTRATION,
+            ),
+            patch.object(manager, "drain") as drain_mock,
+        ):
+            result = manager.service_maintenance()
+        drain_mock.assert_called_once()
+        manager.funding_manager.get_withdrawal_lock.assert_called_once_with(
+            service_config_id=service.service_config_id, chain=Chain.GNOSIS
+        )
+        lock.acquire.assert_called_once_with(blocking=False)
+        lock.release.assert_called_once_with()
+        assert result["processed"] == [f"{service.service_config_id}:{_CHAIN}"]
+
+    def test_withdrawal_lock_released_when_state_gate_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """The withdrawal lock is released even when the state gate skips."""
+        service = _make_maintenance_service()
+        manager = _make_manager(tmp_path)
+        wallet = MagicMock()
+        wallet.safes = {Chain.GNOSIS: "0xMasterSafe"}
+        manager.wallet_manager.load.return_value = wallet
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        manager.funding_manager.get_withdrawal_lock.return_value = lock
+        with (
+            patch.object(manager, "get_all_services", return_value=([service], True)),
+            patch.object(
+                manager, "_get_on_chain_state", return_value=OnChainState.DEPLOYED
+            ),
+            patch.object(manager, "drain") as drain_mock,
+        ):
+            manager.service_maintenance()
+        drain_mock.assert_not_called()
+        lock.release.assert_called_once_with()

--- a/tests/test_utils_gas.py
+++ b/tests/test_utils_gas.py
@@ -202,6 +202,16 @@ class TestPreflightSignerGas:
         with pytest.raises(InsufficientFundsException):
             _enter_preflight(ledger)
 
+    def test_zero_max_fee_is_not_misrouted_to_gas_price(self) -> None:
+        """A zero maxFeePerGas (zero-basefee chain) must yield a zero threshold, not gasPrice's."""
+        ledger = MagicMock()
+        ledger.get_balance.return_value = 0
+        ledger.try_get_gas_pricing.return_value = {
+            "maxFeePerGas": 0,
+            "gasPrice": GAS_PRICE,
+        }
+        _enter_preflight(ledger)  # must not raise
+
     def test_non_int_balance_skips_check(self) -> None:
         """Non-int get_balance return (e.g. MagicMock in tests) skips check safely."""
         ledger = MagicMock()

--- a/tests/test_utils_gas.py
+++ b/tests/test_utils_gas.py
@@ -19,11 +19,40 @@
 
 """Tests for operate/utils/gas.py — direct unit tests for wrap_gas_spike_as_insufficient_funds."""
 
+from unittest.mock import MagicMock
+
 import pytest
+from aea_ledger_ethereum import EIP1559, get_default_gas_strategy
 from autonomy.chain.exceptions import ChainInteractionError
 
 from operate.exceptions import InsufficientFundsException
-from operate.utils.gas import wrap_gas_spike_as_insufficient_funds
+from operate.utils.gas import MIN_GAS_UNITS, wrap_gas_spike_as_insufficient_funds
+
+CHAIN = "gnosis"
+GNOSIS_CHAIN_ID = 100
+SIGNER = "0xSigner"
+GAS_PRICE = 10_000_000_000  # 10 Gwei
+FALLBACK_GAS_PRICE = get_default_gas_strategy(GNOSIS_CHAIN_ID)[EIP1559][
+    "fallback_estimate"
+]["maxFeePerGas"]
+
+
+def _make_ledger(balance: int, gas_price: int = GAS_PRICE) -> MagicMock:
+    ledger = MagicMock()
+    ledger.get_balance.return_value = balance
+    ledger.try_get_gas_pricing.return_value = {"maxFeePerGas": gas_price}
+    return ledger
+
+
+def _healthy_ledger() -> MagicMock:
+    """A ledger whose signer balance comfortably passes the pre-flight check."""
+    return _make_ledger(balance=GAS_PRICE * MIN_GAS_UNITS * 10)
+
+
+def _enter_preflight(ledger: MagicMock) -> None:
+    """Enter and exit the guarded block; raises if the pre-flight check fires."""
+    with wrap_gas_spike_as_insufficient_funds(CHAIN, "transfer", ledger, SIGNER):
+        pass
 
 
 class TestWrapGasSpikeAsInsufficientFunds:
@@ -34,7 +63,9 @@ class TestWrapGasSpikeAsInsufficientFunds:
         original = ValueError("insufficient funds for gas * price + value")
         with (
             pytest.raises(InsufficientFundsException) as exc_info,
-            wrap_gas_spike_as_insufficient_funds("gnosis", "test action"),
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
         ):
             raise original
         assert exc_info.value.__cause__ is original
@@ -44,7 +75,9 @@ class TestWrapGasSpikeAsInsufficientFunds:
         original = ChainInteractionError("max fee per gas less than block base fee")
         with (
             pytest.raises(InsufficientFundsException) as exc_info,
-            wrap_gas_spike_as_insufficient_funds("gnosis", "test action"),
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
         ):
             raise original
         assert exc_info.value.__cause__ is original
@@ -54,7 +87,9 @@ class TestWrapGasSpikeAsInsufficientFunds:
         original = ValueError("contract reverted")
         with (
             pytest.raises(ValueError, match="contract reverted"),
-            wrap_gas_spike_as_insufficient_funds("gnosis", "test action"),
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
         ):
             raise original
 
@@ -63,7 +98,9 @@ class TestWrapGasSpikeAsInsufficientFunds:
         original = ChainInteractionError("nonce too low")
         with (
             pytest.raises(ChainInteractionError, match="nonce too low"),
-            wrap_gas_spike_as_insufficient_funds("gnosis", "test action"),
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
         ):
             raise original
 
@@ -71,20 +108,117 @@ class TestWrapGasSpikeAsInsufficientFunds:
         """Verify the chain field on InsufficientFundsException is set from the argument."""
         with (
             pytest.raises(InsufficientFundsException) as exc_info,
-            wrap_gas_spike_as_insufficient_funds("ethereum", "deploy safe"),
+            wrap_gas_spike_as_insufficient_funds(
+                "ethereum", "deploy safe", _healthy_ledger(), SIGNER
+            ),
         ):
             raise ValueError("insufficient funds for gas * price + value")
         assert exc_info.value.chain == "ethereum"
 
     def test_no_exception_passes_through(self) -> None:
         """Verify the context manager does nothing when no exception is raised."""
-        with wrap_gas_spike_as_insufficient_funds("gnosis", "test action"):
+        with wrap_gas_spike_as_insufficient_funds(
+            CHAIN, "test action", _healthy_ledger(), SIGNER
+        ):
             pass  # Should not raise
 
     def test_unrelated_exception_type_propagates(self) -> None:
         """Verify exceptions other than ValueError/ChainInteractionError propagate."""
         with (
             pytest.raises(RuntimeError, match="something else"),
-            wrap_gas_spike_as_insufficient_funds("gnosis", "test action"),
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
         ):
             raise RuntimeError("something else")
+
+
+class TestPreflightSignerGas:
+    """Unit tests for the pre-flight path of wrap_gas_spike_as_insufficient_funds."""
+
+    def test_balance_zero_fires_immediately(self) -> None:
+        """Zero balance raises InsufficientFundsException before yielding."""
+        ledger = _make_ledger(balance=0)
+        with pytest.raises(InsufficientFundsException) as exc_info:
+            _enter_preflight(ledger)
+        assert exc_info.value.chain == CHAIN
+        assert (
+            exc_info.value.to_error_fields()["error_code"] == "INSUFFICIENT_SIGNER_GAS"
+        )
+
+    def test_dust_balance_below_threshold_fires(self) -> None:
+        """Balance far below gas_price * MIN_GAS_UNITS raises immediately."""
+        threshold = GAS_PRICE * MIN_GAS_UNITS
+        ledger = _make_ledger(balance=threshold // 1000)
+        with pytest.raises(InsufficientFundsException):
+            _enter_preflight(ledger)
+
+    def test_sufficient_balance_passes_through(self) -> None:
+        """Balance exactly above threshold lets body execute normally."""
+        threshold = GAS_PRICE * MIN_GAS_UNITS
+        ledger = _make_ledger(balance=threshold + 1)
+        executed = []
+        with wrap_gas_spike_as_insufficient_funds(CHAIN, "transfer", ledger, SIGNER):
+            executed.append(True)
+        assert executed == [True]
+
+    def test_fast_path_skips_gas_pricing_rpc(self) -> None:
+        """Balance above the fallback-estimate threshold never calls try_get_gas_pricing."""
+        ledger = _make_ledger(balance=FALLBACK_GAS_PRICE * MIN_GAS_UNITS)
+        _enter_preflight(ledger)
+        ledger.try_get_gas_pricing.assert_not_called()
+
+    def test_gray_zone_low_live_price_passes(self) -> None:
+        """Balance below the fallback threshold passes when live gas price is low enough."""
+        low_gas_price = FALLBACK_GAS_PRICE // 5
+        balance = low_gas_price * MIN_GAS_UNITS + 1
+        assert balance < FALLBACK_GAS_PRICE * MIN_GAS_UNITS
+        ledger = _make_ledger(balance=balance, gas_price=low_gas_price)
+        _enter_preflight(ledger)
+        ledger.try_get_gas_pricing.assert_called_once()
+
+    def test_get_balance_raises_is_swallowed(self) -> None:
+        """RPC error in get_balance is swallowed; body executes normally."""
+        ledger = MagicMock()
+        ledger.get_balance.side_effect = RuntimeError("RPC down")
+        executed = []
+        with wrap_gas_spike_as_insufficient_funds(CHAIN, "transfer", ledger, SIGNER):
+            executed.append(True)
+        assert executed == [True]
+
+    def test_no_gas_pricing_uses_fallback_estimate_fires(self) -> None:
+        """When try_get_gas_pricing returns None, the chain's fallback_estimate gas price is used."""
+        ledger = MagicMock()
+        ledger.get_balance.return_value = FALLBACK_GAS_PRICE * MIN_GAS_UNITS - 1
+        ledger.try_get_gas_pricing.return_value = None
+        with pytest.raises(InsufficientFundsException):
+            _enter_preflight(ledger)
+
+    def test_legacy_gas_price_key_used_as_threshold(self) -> None:
+        """Legacy gasPrice key (no maxFeePerGas) is used to compute threshold."""
+        ledger = MagicMock()
+        ledger.get_balance.return_value = 0
+        ledger.try_get_gas_pricing.return_value = {"gasPrice": GAS_PRICE}
+        with pytest.raises(InsufficientFundsException):
+            _enter_preflight(ledger)
+
+    def test_non_int_balance_skips_check(self) -> None:
+        """Non-int get_balance return (e.g. MagicMock in tests) skips check safely."""
+        ledger = MagicMock()
+        ledger.get_balance.return_value = MagicMock()  # not an int
+        ledger.try_get_gas_pricing.return_value = {"maxFeePerGas": GAS_PRICE}
+        executed = []
+        with wrap_gas_spike_as_insufficient_funds(CHAIN, "transfer", ledger, SIGNER):
+            executed.append(True)
+        assert executed == [True]
+
+    def test_existing_message_path_still_works_with_preflight(self) -> None:
+        """Sufficient balance passes pre-flight; gas-spike ValueError in body still raises InsufficientFundsException."""
+        with (
+            pytest.raises(InsufficientFundsException) as exc_info,
+            wrap_gas_spike_as_insufficient_funds(
+                CHAIN, "test action", _healthy_ledger(), SIGNER
+            ),
+        ):
+            raise ValueError("insufficient funds for gas * price + value")
+        assert exc_info.value.chain == CHAIN

--- a/uv.lock
+++ b/uv.lock
@@ -329,76 +329,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bcrypt"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
-    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
-    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
-    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
-    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
-    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
-    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
-    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
-    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
-    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
-    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
-    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
-]
-
-[[package]]
 name = "bech32"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -845,10 +775,9 @@ wheels = [
 
 [[package]]
 name = "cosmpy"
-version = "0.11.2"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bcrypt" },
     { name = "bech32" },
     { name = "ecdsa" },
     { name = "googleapis-common-protos" },
@@ -856,15 +785,14 @@ dependencies = [
     { name = "jsonschema" },
     { name = "protobuf" },
     { name = "pycryptodome" },
-    { name = "pynacl" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "sortedcontainers" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/44/f2a9767f8ed6c5f94664d38f8da716923ae545167c0fd14b322fcbb20c01/cosmpy-0.11.2.tar.gz", hash = "sha256:9dcebaf56d0b971992f462527460f3bd23415a393512b4fe56aaefd2f5e2218d", size = 204546, upload-time = "2025-10-17T12:43:08.715Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c6/c099a691cb1a5b9df8c136c34e6b619f80de927822be68213c2b9c0666dd/cosmpy-0.11.1.tar.gz", hash = "sha256:faffd77308631f4f9f6447ada5742d05bbfb169914fea34e1f7577664c41199d", size = 201729, upload-time = "2025-06-05T16:49:08.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/b0/efbc82f64459cb5842a9b51da02f42591b11cee568f6aeaf4488ad570716/cosmpy-0.11.2-py3-none-any.whl", hash = "sha256:23ef14b803a1d5823befd6b0babc1f9786da578146f5162b7ea818afc1519dc6", size = 424479, upload-time = "2025-10-17T12:43:07.336Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ed/06988f31e86addea82f4301887b5b8146606c0ecff0319b1994276e520a7/cosmpy-0.11.1-py3-none-any.whl", hash = "sha256:11646d796ce1c518ac4e4b7b2301d59bfee0609811a52eb9c76f71fd2afb597d", size = 421140, upload-time = "2025-06-05T16:49:07.138Z" },
 ]
 
 [[package]]
@@ -2070,7 +1998,7 @@ requires-dist = [
     { name = "open-aea-cli-ipfs", specifier = ">=2.2.5,<3" },
     { name = "open-aea-ledger-cosmos", specifier = ">=2.2.5,<3" },
     { name = "open-aea-ledger-ethereum", specifier = ">=2.2.5,<3" },
-    { name = "open-autonomy", extras = ["cli", "docker"], specifier = ">=0.21.21,<0.22" },
+    { name = "open-autonomy", extras = ["cli", "docker"], specifier = ">=0.21.24,<0.22" },
     { name = "psutil", specifier = ">=5.9.8,<6" },
     { name = "requests", specifier = ">=2.32,<3" },
     { name = "uvicorn", specifier = ">=0.30" },
@@ -2093,15 +2021,15 @@ development = [
 
 [[package]]
 name = "open-aea"
-version = "2.2.6"
+version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/81/5c826ac53ed56a95ee4a7266ff5eeb376d6edad38375cc02020a2ca62e3f/open_aea-2.2.6.tar.gz", hash = "sha256:0bddfcdc2072b692bc16e125f424f182a5b01ffafb6715474755ad420262fa8e", size = 499344, upload-time = "2026-05-14T16:30:05.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/2f/3a222b795b0986ce01af32ed8f462ef2d8c2c4cf115c038b16e0819bfe0c/open_aea-2.2.8.tar.gz", hash = "sha256:dbd57af1c9006e150d34bff9515d9417e813dd2d4a02da4aa454cc033dff7ace", size = 503669, upload-time = "2026-06-08T14:10:41.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/6c/8a7f374be05c3df4ae415414f75b885ad83a96d784533daa6d40ae21813d/open_aea-2.2.6-py3-none-any.whl", hash = "sha256:be66a8403a6e13c8204af03a966bf0c6d046344d52e5d1e2789d9a9b1639dac8", size = 684301, upload-time = "2026-05-14T16:30:04.342Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d3/b8c03ae0a10b2841ad427183f2033a4b153105fd23f7eb615cae57416064/open_aea-2.2.8-py3-none-any.whl", hash = "sha256:70171aca774bf371c8d785091d899a3653225fb350ce77a06eb45ed0ffffed91", size = 688617, upload-time = "2026-06-08T14:10:39.982Z" },
 ]
 
 [package.optional-dependencies]
@@ -2115,20 +2043,20 @@ all = [
 
 [[package]]
 name = "open-aea-cli-ipfs"
-version = "2.2.6"
+version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "open-aea" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/fc/72ed0cbd9f161570d1216416c8641118d955c6adeda5bef9316363ad7d1e/open_aea_cli_ipfs-2.2.6.tar.gz", hash = "sha256:00f2e8faf57f60e5cf988ce4f507c7f4cf723720fb5d78e5853a5a1e095fdc4f", size = 30207, upload-time = "2026-05-14T16:30:15.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/18/169bb16ac25ccc5892b59f3be0ae6deda5db5303a9af01892cd9fc3caf10/open_aea_cli_ipfs-2.2.8.tar.gz", hash = "sha256:6338f8a78a0420e067e2366e0da1106735c0e8db73a36e34f215923df54743a6", size = 30231, upload-time = "2026-06-08T14:10:50.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/6b/df1693abc38dcf7c8c54796b92840dc09260eebff387f7cc776060e1669b/open_aea_cli_ipfs-2.2.6-py3-none-any.whl", hash = "sha256:3fefd1e5521530273f5f4c1d1fe67716d38be143d0191a3e1aef8d688a17162a", size = 24732, upload-time = "2026-05-14T16:30:14.156Z" },
+    { url = "https://files.pythonhosted.org/packages/07/4f/4ed077c5a8e3725cb12db29a88e9fbba98043c135296d678375c3ef0eb0f/open_aea_cli_ipfs-2.2.8-py3-none-any.whl", hash = "sha256:defbe074b826e4f956b84804d0dbd943a949ce20ae90539f56e0dba08fdd3690", size = 24732, upload-time = "2026-06-08T14:10:49.96Z" },
 ]
 
 [[package]]
 name = "open-aea-ledger-cosmos"
-version = "2.2.6"
+version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bech32" },
@@ -2138,9 +2066,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/34/61bdeb2bf585d0fd7f8e6d5f4dc6cd0aa96d8b08facb5907067a42cf7c3a/open_aea_ledger_cosmos-2.2.6.tar.gz", hash = "sha256:b7ba0b4822ac04686f4953b2280b338f3858f9acc4cea76702f108e81460848b", size = 113860, upload-time = "2026-05-14T16:30:19.187Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/5a/cf67dab8455a2f2296bfc1402ec4e62861a01103b88b41eef3bf0aa4327c/open_aea_ledger_cosmos-2.2.8.tar.gz", hash = "sha256:1a59cd48e78c21f7af959df84cf350beb8c2f32f08bf71c8eab369e681a2286c", size = 113856, upload-time = "2026-06-08T14:10:54.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/cc/a4987379a67ab924813639508dcf31ff268fc53bbff3791df74c0086e50c/open_aea_ledger_cosmos-2.2.6-py3-none-any.whl", hash = "sha256:43abdeeeb9fc988634bc2f5d0756b38005434857b422806e1be809d63cca49f5", size = 21350, upload-time = "2026-05-14T16:30:18.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/46/c021cc3746582d0e02a26ed27c3eb563851a0964645b75c4de7b9bf86713/open_aea_ledger_cosmos-2.2.8-py3-none-any.whl", hash = "sha256:ce0fa1b64aaae333a85d233c00073b4926348c39d1ebc2c907971aa2b0043dec", size = 21350, upload-time = "2026-06-08T14:10:53.97Z" },
 ]
 
 [[package]]
@@ -2160,7 +2088,7 @@ wheels = [
 
 [[package]]
 name = "open-aea-ledger-solana"
-version = "2.2.6"
+version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anchorpy" },
@@ -2169,14 +2097,14 @@ dependencies = [
     { name = "solana" },
     { name = "solders" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/ed/0ec8bb5ccf4adfde69003505af9ed71673df4571bdd3fecb06cc34d2d450/open_aea_ledger_solana-2.2.6.tar.gz", hash = "sha256:95f9473e3aa0f5b5d2aab5b0338a2578faf7073442ec10c8e1414b30c71de3a9", size = 132628, upload-time = "2026-05-14T16:30:32.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ab/fbb23476c83accb6c6bf8993cd66ab6d6ca1e79f4532944b7fa548cd0edd/open_aea_ledger_solana-2.2.8.tar.gz", hash = "sha256:f13103ff97b850905ce3dcfa20df0c3646a118eed908b5c36098f11fdee860dd", size = 132613, upload-time = "2026-06-08T14:11:07.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/e8/706bc7297449dcf18c82846f3e5548295ced10ff74740899b4b18b9780db/open_aea_ledger_solana-2.2.6-py3-none-any.whl", hash = "sha256:5fe99d1424bf333c71c32c08103024d0bb35f3f384cce4403e0a85711e640b8d", size = 28097, upload-time = "2026-05-14T16:30:31.219Z" },
+    { url = "https://files.pythonhosted.org/packages/40/25/d81d28fa31329bd52ef995386459cb96af1cd7c7e2208602a57e6c5bca39/open_aea_ledger_solana-2.2.8-py3-none-any.whl", hash = "sha256:bbe645dd31964c8908d2c673465f0b680e81e8acdfb5b010afe21b31681935ab", size = 28094, upload-time = "2026-06-08T14:11:06.537Z" },
 ]
 
 [[package]]
 name = "open-autonomy"
-version = "0.21.22"
+version = "0.21.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2190,13 +2118,13 @@ dependencies = [
     { name = "open-aea-ledger-solana" },
     { name = "protobuf" },
     { name = "py-ecc" },
-    { name = "pytest-asyncio" },
+    { name = "pynacl" },
     { name = "requests" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/8e/b64b2744974b5429538a39f4eb6c43f8d9a2ea91a109301eb3eff78bdbcd/open_autonomy-0.21.22.tar.gz", hash = "sha256:77484069db60886b61cbf1e971f3ef61055210d13e4216dbc79ccd31d5691100", size = 1156895, upload-time = "2026-05-18T08:02:43.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/42/8f487b46ff3759fbe6329a5ee0929f8d2fcd407758a5e84432e1dd94a84d/open_autonomy-0.21.24.tar.gz", hash = "sha256:abf05354ae5d4997c4266e8b0d96f913f843bfb755287d58fd1cd39f8b8f2733", size = 1164237, upload-time = "2026-06-09T15:00:58.126Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/ec/7abe10e0cb3d6ae7bc783f971e40b0e8f78c25af38ec8d5f574b58ae2f9e/open_autonomy-0.21.22-py3-none-any.whl", hash = "sha256:c5393b2d374ac1d22943d7324f0a50dd8684d1e7bae8ffbffe92a81ee4571454", size = 1666519, upload-time = "2026-05-18T08:02:41.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/efa07d39842388c9351499c3b62647d841450e3c7ca7d68f21213794ef8b/open_autonomy-0.21.24-py3-none-any.whl", hash = "sha256:3da9ed8eddfc3f1ef35d6b17cb805736c8adf9a9c7828324ac9e32d98bf729c2", size = 1674377, upload-time = "2026-06-09T15:00:56.532Z" },
 ]
 
 [package.optional-dependencies]
@@ -2633,39 +2561,37 @@ wheels = [
 
 [[package]]
 name = "pynacl"
-version = "1.6.0"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c6/a3124dee667a423f2c637cfd262a54d67d8ccf3e160f3c50f622a85b7723/pynacl-1.6.0.tar.gz", hash = "sha256:cb36deafe6e2bce3b286e5d1f3e1c246e0ccdb8808ddb4550bb2792f2df298f2", size = 3505641, upload-time = "2025-09-10T23:39:22.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/24/1b639176401255605ba7c2b93a7b1eb1e379e0710eca62613633eb204201/pynacl-1.6.0-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:f46386c24a65383a9081d68e9c2de909b1834ec74ff3013271f1bca9c2d233eb", size = 384141, upload-time = "2025-09-10T23:38:28.675Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7b/874efdf57d6bf172db0df111b479a553c3d9e8bb4f1f69eb3ffff772d6e8/pynacl-1.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dea103a1afcbc333bc0e992e64233d360d393d1e63d0bc88554f572365664348", size = 808132, upload-time = "2025-09-10T23:38:38.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/61/9b53f5913f3b75ac3d53170cdb897101b2b98afc76f4d9d3c8de5aa3ac05/pynacl-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:04f20784083014e265ad58c1b2dd562c3e35864b5394a14ab54f5d150ee9e53e", size = 1407253, upload-time = "2025-09-10T23:38:40.492Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0a/b138916b22bbf03a1bdbafecec37d714e7489dd7bcaf80cd17852f8b67be/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbcc4452a1eb10cd5217318c822fde4be279c9de8567f78bad24c773c21254f8", size = 843719, upload-time = "2025-09-10T23:38:30.87Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3b/17c368197dfb2c817ce033f94605a47d0cc27901542109e640cef263f0af/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51fed9fe1bec9e7ff9af31cd0abba179d0e984a2960c77e8e5292c7e9b7f7b5d", size = 1445441, upload-time = "2025-09-10T23:38:33.078Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3c/f79b185365ab9be80cd3cd01dacf30bf5895f9b7b001e683b369e0bb6d3d/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:10d755cf2a455d8c0f8c767a43d68f24d163b8fe93ccfaabfa7bafd26be58d73", size = 825691, upload-time = "2025-09-10T23:38:34.832Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/1f/8b37d25e95b8f2a434a19499a601d4d272b9839ab8c32f6b0fc1e40c383f/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:536703b8f90e911294831a7fbcd0c062b837f3ccaa923d92a6254e11178aaf42", size = 1410726, upload-time = "2025-09-10T23:38:36.893Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/93/5a4a4cf9913014f83d615ad6a2df9187330f764f606246b3a744c0788c03/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6b08eab48c9669d515a344fb0ef27e2cbde847721e34bba94a343baa0f33f1f4", size = 801035, upload-time = "2025-09-10T23:38:42.109Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/60/40da6b0fe6a4d5fd88f608389eb1df06492ba2edca93fca0b3bebff9b948/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5789f016e08e5606803161ba24de01b5a345d24590a80323379fc4408832d290", size = 1371854, upload-time = "2025-09-10T23:38:44.16Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b2/37ac1d65008f824cba6b5bf68d18b76d97d0f62d7a032367ea69d4a187c8/pynacl-1.6.0-cp314-cp314t-win32.whl", hash = "sha256:4853c154dc16ea12f8f3ee4b7e763331876316cc3a9f06aeedf39bcdca8f9995", size = 230345, upload-time = "2025-09-10T23:38:48.276Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/5a/9234b7b45af890d02ebee9aae41859b9b5f15fb4a5a56d88e3b4d1659834/pynacl-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:347dcddce0b4d83ed3f32fd00379c83c425abee5a9d2cd0a2c84871334eaff64", size = 243103, upload-time = "2025-09-10T23:38:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2c/c1a0f19d720ab0af3bc4241af2bdf4d813c3ecdcb96392b5e1ddf2d8f24f/pynacl-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2d6cd56ce4998cb66a6c112fda7b1fdce5266c9f05044fa72972613bef376d15", size = 187778, upload-time = "2025-09-10T23:38:46.731Z" },
-    { url = "https://files.pythonhosted.org/packages/63/37/87c72df19857c5b3b47ace6f211a26eb862ada495cc96daa372d96048fca/pynacl-1.6.0-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:f4b3824920e206b4f52abd7de621ea7a44fd3cb5c8daceb7c3612345dfc54f2e", size = 382610, upload-time = "2025-09-10T23:38:49.459Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/64/3ce958a5817fd3cc6df4ec14441c43fd9854405668d73babccf77f9597a3/pynacl-1.6.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:16dd347cdc8ae0b0f6187a2608c0af1c8b7ecbbe6b4a06bff8253c192f696990", size = 798744, upload-time = "2025-09-10T23:38:58.531Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/8a/3f0dd297a0a33fa3739c255feebd0206bb1df0b44c52fbe2caf8e8bc4425/pynacl-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16c60daceee88d04f8d41d0a4004a7ed8d9a5126b997efd2933e08e93a3bd850", size = 1397879, upload-time = "2025-09-10T23:39:00.44Z" },
-    { url = "https://files.pythonhosted.org/packages/41/94/028ff0434a69448f61348d50d2c147dda51aabdd4fbc93ec61343332174d/pynacl-1.6.0-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25720bad35dfac34a2bcdd61d9e08d6bfc6041bebc7751d9c9f2446cf1e77d64", size = 833907, upload-time = "2025-09-10T23:38:50.936Z" },
-    { url = "https://files.pythonhosted.org/packages/52/bc/a5cff7f8c30d5f4c26a07dfb0bcda1176ab8b2de86dda3106c00a02ad787/pynacl-1.6.0-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bfaa0a28a1ab718bad6239979a5a57a8d1506d0caf2fba17e524dbb409441cf", size = 1436649, upload-time = "2025-09-10T23:38:52.783Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/20/c397be374fd5d84295046e398de4ba5f0722dc14450f65db76a43c121471/pynacl-1.6.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ef214b90556bb46a485b7da8258e59204c244b1b5b576fb71848819b468c44a7", size = 817142, upload-time = "2025-09-10T23:38:54.4Z" },
-    { url = "https://files.pythonhosted.org/packages/12/30/5efcef3406940cda75296c6d884090b8a9aad2dcc0c304daebb5ae99fb4a/pynacl-1.6.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:49c336dd80ea54780bcff6a03ee1a476be1612423010472e60af83452aa0f442", size = 1401794, upload-time = "2025-09-10T23:38:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/be/e1/a8fe1248cc17ccb03b676d80fa90763760a6d1247da434844ea388d0816c/pynacl-1.6.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f3482abf0f9815e7246d461fab597aa179b7524628a4bc36f86a7dc418d2608d", size = 772161, upload-time = "2025-09-10T23:39:01.93Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/76/8a62702fb657d6d9104ce13449db221a345665d05e6a3fdefb5a7cafd2ad/pynacl-1.6.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:140373378e34a1f6977e573033d1dd1de88d2a5d90ec6958c9485b2fd9f3eb90", size = 1370720, upload-time = "2025-09-10T23:39:03.531Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/38/9e9e9b777a1c4c8204053733e1a0269672c0bd40852908c9ad6b6eaba82c/pynacl-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6b393bc5e5a0eb86bb85b533deb2d2c815666665f840a09e0aa3362bb6088736", size = 791252, upload-time = "2025-09-10T23:39:05.058Z" },
-    { url = "https://files.pythonhosted.org/packages/63/ef/d972ce3d92ae05c9091363cf185e8646933f91c376e97b8be79ea6e96c22/pynacl-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4a25cfede801f01e54179b8ff9514bd7b5944da560b7040939732d1804d25419", size = 1362910, upload-time = "2025-09-10T23:39:06.924Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2c/ee0b373a1861f66a7ca8bdb999331525615061320dd628527a50ba8e8a60/pynacl-1.6.0-cp38-abi3-win32.whl", hash = "sha256:dcdeb41c22ff3c66eef5e63049abf7639e0db4edee57ba70531fc1b6b133185d", size = 226461, upload-time = "2025-09-10T23:39:11.894Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f7/41b6c0b9dd9970173b6acc026bab7b4c187e4e5beef2756d419ad65482da/pynacl-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:cf831615cc16ba324240de79d925eacae8265b7691412ac6b24221db157f6bd1", size = 238802, upload-time = "2025-09-10T23:39:08.966Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0f/462326910c6172fa2c6ed07922b22ffc8e77432b3affffd9e18f444dbfbb/pynacl-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:84709cea8f888e618c21ed9a0efdb1a59cc63141c403db8bf56c469b71ad56f2", size = 183846, upload-time = "2025-09-10T23:39:10.552Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1950,7 +1950,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.27"
+version = "0.15.28"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Proposed changes

Fixes OPE-1770: a partial ERC20 withdrawal with a gas-starved signer EOA surfaced as a generic 500 after a ~5-minute retry loop, instead of the standardized `INSUFFICIENT_SIGNER_GAS` error code.

Two changes:

1. **Bump open-autonomy to `>=0.21.24`.** In 0.21.22, `TxSettler` discarded the underlying RPC error when raising `ChainTimeoutError` after 60 repricing retries, so `is_gas_spike_error` only saw a context-free timeout string. 0.21.24 embeds the last error (containing the `-32000` code) in the timeout message, which the existing classification matches.

2. **Universal pre-flight signer gas check.** `wrap_gas_spike_as_insufficient_funds` — the chokepoint wrapping every guarded transaction flow (Safe creation/ops, EOA native + ERC20 transfers, bridge txs, staking settle) — now takes required `ledger_api`/`signer_address` params and verifies the signer can afford `gas_price × MIN_GAS_UNITS` before entering the guarded block. A signer with effectively-zero balance now gets `InsufficientFundsException` (→ `INSUFFICIENT_SIGNER_GAS`) in under a second instead of after the retry loop. Healthy wallets cost a single `get_balance` RPC: the live gas-pricing lookup only happens when the balance is below the chain-aware fallback threshold from aea-ledger-ethereum's `get_default_gas_strategy` (the same fallback estimate `EthereumApi` itself prices with). Any pre-flight error (RPC down, unknown chain) is swallowed, degrading to the previous behavior.

Also includes:
- **`.claude/settings.json` hook fix:** the Bash PreToolUse hook used a relative path (`python3 .claude/hooks/advise-code-review.py`), which broke whenever the shell cwd was not the repo root; it now resolves via `$CLAUDE_PROJECT_DIR`.

Note: the `uv.lock` regeneration also moved open-aea 2.2.6→2.2.8, pynacl 1.6.0→1.6.2, and downgraded cosmpy 0.11.2→0.11.1 per the resolver.

**Testing:**
- 17 unit tests for the wrapper (pre-flight fires/passes, fast path skips pricing RPC, gray-zone live pricing, fallback estimate, RPC-error resilience, message-translation path intact)
- Tenderly integration: `test_transfer` + `test_transfer_error_funds` (Gnosis) pass — they drive Safe creation and native/ERC20 transfers end-to-end through the new pre-flight
- Full lint/type suite green (flake8, pylint 10.00/10, black, isort, mypy)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
