### PR TITLE
fix: make deployment stop/transition crash-safe to avoid wedged services

### DIFF
--- a/operate/cli.py
+++ b/operate/cli.py
@@ -571,8 +571,25 @@ def create_app(  # pylint: disable=too-many-locals, unused-argument, too-many-st
             run_in_executor(operate.service_manager().service_maintenance)
         )
 
+    def recover_stale_deployment_statuses() -> None:
+        """Heal services left mid-transition by a crash before pausing them."""
+        service_manager = operate.service_manager()
+        for entry in service_manager.json:
+            service_config_id = entry["service_config_id"]
+            if not service_manager.exists(service_config_id=service_config_id):
+                continue
+            deployment = service_manager.load(
+                service_config_id=service_config_id
+            ).deployment
+            if deployment.recover_stale_transition_status():
+                logger.warning(
+                    f"Recovered service {service_config_id} from a stale "
+                    f"transitional deployment status (set to BUILT)."
+                )
+
     def pause_all_services_on_startup() -> None:
         logger.info("Stopping services on startup...")
+        recover_stale_deployment_statuses()
         pause_all_services()
         logger.info("Stopping services on startup done.")
 

--- a/operate/services/service.py
+++ b/operate/services/service.py
@@ -765,16 +765,44 @@ class Deployment(LocalResource):
         self.status = DeploymentStatus.STOPPING
         self.store()
 
-        if use_docker:
-            stop_deployment(
-                build_dir=self.path / DEPLOYMENT_DIR,
-                project_name=self.path.name,
-            )
-        else:
-            stop_host_deployment(build_dir=self.path / DEPLOYMENT_DIR, is_aea=is_aea)
+        try:
+            if use_docker:
+                stop_deployment(
+                    build_dir=self.path / DEPLOYMENT_DIR,
+                    project_name=self.path.name,
+                )
+            else:
+                stop_host_deployment(
+                    build_dir=self.path / DEPLOYMENT_DIR, is_aea=is_aea
+                )
+        except Exception:
+            # Never leave the deployment persisted in the transient STOPPING
+            # state. A stop that raises (e.g. "Service already in transition")
+            # would otherwise wedge the service so it can be neither started nor
+            # stopped from the UI. BUILT is the recoverable terminal state, and
+            # mirrors the failure handling in start().
+            self.status = DeploymentStatus.BUILT
+            self.store()
+            raise
 
         self.status = DeploymentStatus.BUILT
         self.store()
+
+    def recover_stale_transition_status(self) -> bool:
+        """Reset a status left transient by a crash, to be called at startup.
+
+        A middleware process killed mid-transition (e.g. SIGKILL while the
+        agent is being set up) can leave the persisted status in DEPLOYING or
+        STOPPING. Such a service is wedged: it can be neither started nor
+        stopped from the UI. At startup no deployment from this fresh process
+        is running yet, so any transient status is stale and is reset to the
+        recoverable BUILT state. Returns True if a reset was performed.
+        """
+        if self.status in (DeploymentStatus.DEPLOYING, DeploymentStatus.STOPPING):
+            self.status = DeploymentStatus.BUILT
+            self.store()
+            return True
+        return False
 
     def delete(self) -> None:
         """Delete the deployment."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olas-operate-middleware"
-version = "0.15.29"
+version = "0.15.30"
 description = ""
 license = "Apache-2.0"
 authors = [

--- a/tests/test_service_unit2.py
+++ b/tests/test_service_unit2.py
@@ -761,6 +761,63 @@ class TestDeploymentStop:
         mock_hstop.assert_called_once()
         assert depl.status == DeploymentStatus.BUILT
 
+    def test_stop_exception_resets_status_to_built(self, tmp_path: Path) -> None:
+        """stop() resets status to BUILT and re-raises when the stop fails.
+
+        Guards against wedging the service in the transient STOPPING state when
+        stop_host_deployment raises (e.g. "Service already in transition").
+        """
+        depl = _make_deployment(tmp_path, DeploymentStatus.DEPLOYED)
+
+        with patch(
+            "operate.services.service.stop_host_deployment",
+            side_effect=ValueError("Service already in transition"),
+        ):
+            with pytest.raises(ValueError, match="already in transition"):
+                depl.stop(force=True)
+
+        assert depl.status == DeploymentStatus.BUILT
+        # The recoverable status is persisted, not just held in memory.
+        assert Deployment.load(path=tmp_path).status == DeploymentStatus.BUILT
+
+
+class TestDeploymentRecoverStaleStatus:
+    """Tests for Deployment.recover_stale_transition_status()."""
+
+    @pytest.mark.parametrize(
+        "stale_status",
+        [DeploymentStatus.DEPLOYING, DeploymentStatus.STOPPING],
+    )
+    def test_resets_transient_status_to_built(
+        self, tmp_path: Path, stale_status: DeploymentStatus
+    ) -> None:
+        """A status left mid-transition by a crash is reset to BUILT."""
+        depl = _make_deployment(tmp_path, stale_status)
+
+        assert depl.recover_stale_transition_status() is True
+        assert depl.status == DeploymentStatus.BUILT
+        # Persisted, so the recovery survives the next load.
+        assert Deployment.load(path=tmp_path).status == DeploymentStatus.BUILT
+
+    @pytest.mark.parametrize(
+        "stable_status",
+        [
+            DeploymentStatus.CREATED,
+            DeploymentStatus.BUILT,
+            DeploymentStatus.DEPLOYED,
+            DeploymentStatus.STOPPED,
+            DeploymentStatus.DELETED,
+        ],
+    )
+    def test_leaves_non_transient_status_untouched(
+        self, tmp_path: Path, stable_status: DeploymentStatus
+    ) -> None:
+        """Statuses that are not mid-transition are left as-is."""
+        depl = _make_deployment(tmp_path, stable_status)
+
+        assert depl.recover_stale_transition_status() is False
+        assert depl.status == stable_status
+
 
 class TestDeploymentDelete:
     """Tests for Deployment.delete()."""

--- a/uv.lock
+++ b/uv.lock
@@ -1950,7 +1950,7 @@ wheels = [
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.29"
+version = "0.15.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Proposed changes

A middleware process killed mid-transition (e.g. `SIGKILL` while the agent is being set up, observed as `aea command ... add-key ... exit code: -9`) could leave a service's persisted deployment status stuck at `STOPPING` or `DEPLOYING` forever. Such a service became **wedged**: it could be neither started nor stopped, and the frontend's autorun toggle stayed locked because it gates on the transitional deployment status.

Root cause: `Service.stop()` persists `STOPPING` *before* doing the work and only advances to `BUILT` *after*; if the process dies (or `stop_host_deployment` raises the swallowed `"Service already in transition"`) in between, the transient status survives. Nothing normalized it on the next launch.

### Changes

- **`Service.stop()` is now crash-safe** — the stop body is wrapped in `try/except`; on failure the status is reset to `BUILT` and the exception re-raised, instead of leaving `STOPPING` persisted. This mirrors the existing failure handling in `start()` and closes the swallowed `"Service already in transition"` path.
- **New `Deployment.recover_stale_transition_status()`** — called at daemon startup (in `pause_all_services_on_startup`) before pausing services. It resets any persisted `DEPLOYING`/`STOPPING` back to `BUILT`. A hard kill cannot be caught by `try/except`, so this self-heals a wedged service on the next launch. Safe by construction: at startup no deployment from the fresh process is running yet, so any transitional status is necessarily stale. Recovered services are logged at `WARNING`.
- **Tests** — added coverage for the `stop()` failure path (resets to and persists `BUILT`) and for `recover_stale_transition_status()` (resets `DEPLOYING`/`STOPPING`, leaves all other statuses untouched).

### Notes

- Frontend (`olas-operate-app`) needs **no change**: it keeps no persisted deployment status and derives `isServiceTransitioning` purely from polling the middleware, so once the backend reports a terminal status the UI unsticks on the next poll (≤5s) and the autorun toggle unlocks.
- Verified: `tox -e flake8 / black-check / isort-check / mypy` all pass; targeted unit suites green (`test_service_unit2.py`, `test_operate_cli.py`, `test_cli_unit.py`).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)